### PR TITLE
feat: 회원 모델 추가 및 테스트 작성

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/domain/member/MemberModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/member/MemberModel.java
@@ -1,0 +1,85 @@
+package com.loopers.domain.member;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.domain.member.enums.Gender;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+
+@Entity
+@Table(name = "member")
+public class MemberModel extends BaseEntity {
+
+    private String userId;
+
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
+
+    private LocalDate birthdate;
+
+    private String email;
+
+    private Long points;
+
+    protected MemberModel() {}
+
+    public MemberModel(String userId, Gender gender, String birthdate, String email) {
+        if (userId == null || userId.isBlank()) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "이름은 비어있을 수 없습니다.");
+        }
+        if (userId.length() > 10 || !userId.matches("^[a-zA-Z0-9]+$")) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "잘못된 형식의 아이디입니다.");
+        }
+        if (gender == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "성별은 비어있을 수 없습니다.");
+        }
+        if (birthdate == null || birthdate.isBlank()) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "생년월일은 비어있을 수 없습니다.");
+        }
+        LocalDate parsedBirthdate = null;
+        try {
+            parsedBirthdate = LocalDate.parse(birthdate);
+        } catch (DateTimeParseException e) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "잘못된 형식의 생년월일입니다.");
+        }
+        if (email == null || email.isBlank()) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "이메일은 비어있을 수 없습니다.");
+        }
+        if (!email.matches("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,6}$")) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "잘못된 형식의 이메일입니다.");
+        }
+
+        this.userId = userId;
+        this.gender = gender;
+        this.birthdate = parsedBirthdate;
+        this.email = email;
+        this.points = 0L;
+    }
+
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public Gender getGender() {
+        return gender;
+    }
+
+    public LocalDate getBirthdate() {
+        return birthdate;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public Long getPoints() {
+        return points;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/member/enums/Gender.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/member/enums/Gender.java
@@ -1,0 +1,6 @@
+package com.loopers.domain.member.enums;
+
+public enum Gender {
+    MALE,
+    FEMALE,
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/member/MemberModelTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/member/MemberModelTest.java
@@ -1,0 +1,93 @@
+package com.loopers.domain.member;
+
+import com.loopers.domain.member.enums.Gender;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class MemberModelTest {
+
+    @DisplayName("회원 모델을 생성할 때, ")
+    @Nested
+    class Create {
+        @DisplayName("아이디와 성별과 생일과 이메일이 모두 주어지면, 정상적으로 생성된다.")
+        @Test
+        void createMemberModel_whenUserIdAndGenderAndBirthdateAndEmailAreProvided() {
+            String userId = "test";
+            Gender gender = Gender.MALE;
+            String birthdate = "2020-01-01";
+            String email = "test@test.com";
+
+            MemberModel memberModel = new MemberModel(userId, gender, birthdate, email);
+
+            assertAll(
+                    () -> assertThat(memberModel.getId()).isNotNull(),
+                    () -> assertThat(memberModel.getUserId()).isEqualTo(userId),
+                    () -> assertThat(memberModel.getGender()).isEqualTo(gender),
+                    () -> assertThat(memberModel.getBirthdate()).isEqualTo(
+                            LocalDate.of(2020, 1, 1)
+                    ),
+                    () -> assertThat(memberModel.getEmail()).isEqualTo(email),
+                    () -> assertThat(memberModel.getPoints()).isEqualTo(0L)
+            );
+        }
+
+        @DisplayName("아이디가 빈칸 혹은 null 이면, BAD_REQUEST 예외가 발생한다")
+        @Test
+        void throwsBadRequestException_whenUserIdIsNullOrBlank() {
+            String blankUserId = "     ";
+
+            CoreException resultWhenNull = assertThrows(CoreException.class, () -> {
+                new MemberModel(null, Gender.MALE, "2020-01-01", "test@test.com");
+            });
+            assertThat(resultWhenNull.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+
+            CoreException resultWhenBlank = assertThrows(CoreException.class, () -> {
+                new MemberModel(blankUserId, Gender.MALE, "2020-01-01", "test@test.com");
+            });
+            assertThat(resultWhenBlank.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+
+        @DisplayName("아이디가 영문 및 숫자 10자 이내 형식에 맞지 않으면, Member 객체 생성에 실패한다.")
+        @Test
+        void throwsBadRequestException_whenUserIdIsNotAlphanumericOrExceedsTenCharacters() {
+            String lengthExceedsTen = "abcde12345678910";
+            String isNotAlphanumeric = "!@#한글";
+
+            CoreException resultWhenLengthExceedsTen = assertThrows(CoreException.class, () -> {
+                new MemberModel(lengthExceedsTen, Gender.MALE, "2020-01-01", "test@test.com");
+            });
+            assertThat(resultWhenLengthExceedsTen.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+
+            CoreException resultWhenIsNotAlphanumeric = assertThrows(CoreException.class, () -> {
+                new MemberModel(isNotAlphanumeric, Gender.MALE, "2020-01-01", "test@test.com");
+            });
+            assertThat(resultWhenIsNotAlphanumeric.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+
+        @DisplayName("이메일이 xx@yy.zz 형식에 맞지 않으면, Member 객체 생성에 실패한다.")
+        @Test
+        void throwsBadRequestException_whenEmailIsNotValid() {
+            CoreException result = assertThrows(CoreException.class, () -> {
+                new MemberModel("test", Gender.MALE, "2020-01-01", "@not.email.com");
+            });
+            assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+
+        @DisplayName("생년월일이 yyyy-MM-dd 형식에 맞지 않으면, Member 객체 생성에 실패한다.")
+        @Test
+        void throwsBadRequestException_whenBirthdateIsNotValid() {
+            CoreException result = assertThrows(CoreException.class, () -> {
+                new MemberModel("test", Gender.MALE, "20/01/01T05:30", "test@test.com");
+            });
+            assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+    }
+}


### PR DESCRIPTION
## 📌 Summary
회원 도메인 모델 추가 및 생성 로직 테스트 작성

## 💬 Review Points
(1) 테스트 메서드 명 네이밍에 대한 고민
아이디가 영문 및 숫자 10자 이내 형식에 맞지 않으면, Member 객체 생성에 실패한다. 라는 테스트에 대하여,
테스트 메서드 명을 지을 때 "영문 및 숫자 10자 이내 형식에 맞지 않다" 라는 문맥을 포함시키는 게 좋을지 아니면 not valid 로 퉁치는게 좋을지 고민입니다.

(2) 도메인 모델에서 엔티티 개념을 분리하는 것이 좋은가?
도메인 모델 클래스가 BaseEntity를 상속 받거나 @Entity 혹은 @Table / @Column 등의 어노테이션을 사용하는 게 좋을지 아니면
infrastructure 단에 entities를 도메인 모델과 따로 구분해서 관리하는 게 좋을지 판단이 안됩니다.
예를 들어 회원 엔티티 입장에서는 PK로 auto increment 되는 아이디 식별자와 별개로 로그인에 쓰일 아이디 컬럼을 별도로 두고 싶은데 회원 도메인 모델 입장에서 PK로 auto increment 되는 아이디 식별자가 필요하다 혹은 존재해야 한다는 정보를 가지고 있어야 하나 싶기도 했습니다. 도메인 모델 입장에서는 로그인에 쓰일 아이디만 들고 있도록 설계할 수도 있을 것 같다는 생각입니다.


## ✅ Checklist

R1. 회원가입 - 단위 테스트
- [x]  ID 가 `영문 및 숫자 10자 이내` 형식에 맞지 않으면, User 객체 생성에 실패한다.
- [x]  이메일이 `xx@yy.zz` 형식에 맞지 않으면, User 객체 생성에 실패한다.
- [x]  생년월일이 `yyyy-MM-dd` 형식에 맞지 않으면, User 객체 생성에 실패한다.