### PR TITLE
feat: 회원가입 추가 및 테스트 작성 그리고 프로젝트 세팅 수정

### DIFF
--- a/apps/commerce-api/build.gradle.kts
+++ b/apps/commerce-api/build.gradle.kts
@@ -11,7 +11,9 @@ dependencies {
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:${project.properties["springDocOpenApiVersion"]}")
 
     // querydsl
-    implementation("com.querydsl:querydsl-jpa::jakarta")
+    annotationProcessor("com.querydsl:querydsl-apt::jakarta")
+    annotationProcessor("jakarta.persistence:jakarta.persistence-api")
+    annotationProcessor("jakarta.annotation:jakarta.annotation-api")
 
     // test-fixtures
     testImplementation(testFixtures(project(":modules:jpa")))

--- a/apps/commerce-api/src/main/java/com/loopers/application/member/MemberFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/member/MemberFacade.java
@@ -1,0 +1,30 @@
+package com.loopers.application.member;
+
+import com.loopers.domain.member.MemberModel;
+import com.loopers.domain.member.MemberService;
+import com.loopers.domain.member.enums.Gender;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class MemberFacade {
+    private final MemberService memberService;
+
+    public MemberInfo signUp(String userId, Gender gender, String birthdate, String email) {
+        try {
+            MemberModel member = memberService.getMember(userId);
+            if (member != null) {
+                throw new CoreException(ErrorType.CONFLICT, "이미 존재하는 회원 아이디 입니다.");
+            }
+        } catch (CoreException e) {
+            if (e.getErrorType() == ErrorType.CONFLICT) {
+                throw e;
+            }
+        }
+
+        return MemberInfo.from(memberService.createMember(userId, gender, birthdate, email));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/member/MemberInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/member/MemberInfo.java
@@ -1,0 +1,19 @@
+package com.loopers.application.member;
+
+import com.loopers.domain.member.MemberModel;
+import com.loopers.domain.member.enums.Gender;
+
+import java.time.LocalDate;
+
+public record MemberInfo(Long id, String userId, Gender gender, LocalDate birthdate, String email, Long points) {
+    public static MemberInfo from(MemberModel model) {
+        return new MemberInfo(
+                model.getId(),
+                model.getUserId(),
+                model.getGender(),
+                model.getBirthdate(),
+                model.getEmail(),
+                model.getPoints()
+        );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/member/MemberRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/member/MemberRepository.java
@@ -1,0 +1,9 @@
+package com.loopers.domain.member;
+
+import java.util.Optional;
+
+public interface MemberRepository {
+    Optional<MemberModel> findByUserId(String userId);
+
+    MemberModel create(MemberModel member);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/member/MemberService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/member/MemberService.java
@@ -1,0 +1,30 @@
+package com.loopers.domain.member;
+
+import com.loopers.domain.member.enums.Gender;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.text.MessageFormat;
+
+@RequiredArgsConstructor
+@Component
+public class MemberService {
+    private final MemberRepository memberRepository;
+
+    @Transactional(readOnly = true)
+    public MemberModel getMember(String userId) {
+        return memberRepository.findByUserId(userId)
+                .orElseThrow(() -> new CoreException(
+                        ErrorType.NOT_FOUND,
+                        MessageFormat.format("[userId = {0}] 회원을 찾을 수 없습니다.", userId)
+                ));
+    }
+
+    @Transactional()
+    public MemberModel createMember(String userId, Gender gender, String birthdate, String email) {
+        return memberRepository.create(new MemberModel(userId, gender, birthdate, email));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/member/MemberJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/member/MemberJpaRepository.java
@@ -1,0 +1,10 @@
+package com.loopers.infrastructure.member;
+
+import com.loopers.domain.member.MemberModel;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberJpaRepository extends JpaRepository<MemberModel, Long> {
+    Optional<MemberModel> findByUserId(String userId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/member/MemberRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/member/MemberRepositoryImpl.java
@@ -1,0 +1,24 @@
+package com.loopers.infrastructure.member;
+
+import com.loopers.domain.member.MemberModel;
+import com.loopers.domain.member.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Repository
+public class MemberRepositoryImpl implements MemberRepository {
+    private final MemberJpaRepository memberJpaRepository;
+
+    @Override
+    public Optional<MemberModel> findByUserId(String userId) {
+        return memberJpaRepository.findByUserId(userId);
+    }
+
+    @Override
+    public MemberModel create(MemberModel member) {
+        return memberJpaRepository.save(member);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/member/MemberV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/member/MemberV1ApiSpec.java
@@ -1,0 +1,18 @@
+package com.loopers.interfaces.api.member;
+
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Member V1 API", description = "회원 API 입니다")
+public interface MemberV1ApiSpec {
+
+    @Operation(
+            summary = "회원가입",
+            description = "제공된 정보로 신규 회원을 생성합니다."
+    )
+    ApiResponse<MemberV1Dto.MemberResponse> signup(
+            @RequestBody MemberV1Dto.SignupRequest dto
+    );
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/member/MemberV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/member/MemberV1Controller.java
@@ -1,0 +1,29 @@
+package com.loopers.interfaces.api.member;
+
+import com.loopers.application.member.MemberFacade;
+import com.loopers.application.member.MemberInfo;
+import com.loopers.interfaces.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/users")
+public class MemberV1Controller implements MemberV1ApiSpec {
+
+    private final MemberFacade memberFacade;
+
+    @PostMapping()
+    @Override
+    public ApiResponse<MemberV1Dto.MemberResponse> signup(MemberV1Dto.SignupRequest dto) {
+        MemberInfo member = memberFacade.signUp(
+                dto.userId(),
+                dto.gender(),
+                dto.birthdate(),
+                dto.email()
+        );
+        return ApiResponse.success(MemberV1Dto.MemberResponse.from(member));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/member/MemberV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/member/MemberV1Dto.java
@@ -1,0 +1,34 @@
+package com.loopers.interfaces.api.member;
+
+import com.loopers.application.member.MemberInfo;
+import com.loopers.domain.member.enums.Gender;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+
+public class MemberV1Dto {
+    public record MemberResponse(Long id, String userId, Gender gender, LocalDate birthdate, String email, Long points) {
+        public static MemberResponse from(MemberInfo member) {
+            return new MemberResponse(
+                    member.id(),
+                    member.userId(),
+                    member.gender(),
+                    member.birthdate(),
+                    member.email(),
+                    member.points()
+            );
+        }
+    }
+
+    public record SignupRequest(
+            @Schema(name = "회원 ID", example = "test")
+            String userId,
+            @Schema(name = "성별", example = "MALE", allowableValues = {"FEMALE", "MALE"})
+            Gender gender,
+            @Schema(name = "생년월일", example = "2000-01-01")
+            String birthdate,
+            @Schema(name = "이메일", example = "test@test.com")
+            String email
+    ) {
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/application/member/MemberFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/member/MemberFacadeIntegrationTest.java
@@ -1,0 +1,68 @@
+package com.loopers.application.member;
+
+import com.loopers.domain.member.MemberService;
+import com.loopers.domain.member.enums.Gender;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+class MemberFacadeIntegrationTest {
+
+    @Autowired
+    private MemberFacade memberFacade;
+
+    @MockitoSpyBean
+    private MemberService memberService;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("회원가입을 할 때")
+    @Nested
+    class SignUp {
+        @DisplayName("회원 가입시 User 저장이 수행된다. ( spy 검증 )")
+        @Test
+        void savesUser_whenSignUpIsCalled() {
+            String userId = "testUser";
+            Gender gender = Gender.MALE;
+            String birthdate = "2000-01-01";
+            String email = "test@test.com";
+
+            MemberInfo memberInfo = memberFacade.signUp(userId, gender, birthdate, email);
+
+            verify(memberService).createMember(userId, gender, birthdate, email);
+
+            assertThat(memberInfo.userId()).isEqualTo(userId);
+            assertThat(memberInfo.gender()).isEqualTo(gender);
+            assertThat(memberInfo.birthdate()).isEqualTo(birthdate);
+            assertThat(memberInfo.email()).isEqualTo(email);
+        }
+
+        @DisplayName("이미 가입된 ID 로 회원가입 시도 시, 실패한다.")
+        @Test
+        void throwsException_whenUserIdAlreadyExists() {
+            String userId = "userA";
+            memberFacade.signUp(userId, Gender.MALE, "2000-01-01", "test@test.com");
+
+            CoreException exception = assertThrows(CoreException.class, () -> memberFacade.signUp(userId, Gender.MALE, "2000-01-01", "test@test.com"));
+            assertThat(exception.getErrorType()).isEqualTo(ErrorType.CONFLICT);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/MemberV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/MemberV1ApiE2ETest.java
@@ -1,0 +1,88 @@
+package com.loopers.interfaces.api;
+
+import com.loopers.domain.member.enums.Gender;
+import com.loopers.interfaces.api.member.MemberV1Dto;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class MemberV1ApiE2ETest {
+
+    private static final String ENDPOINT_SIGNUP = "/api/v1/users";
+
+    private final TestRestTemplate testRestTemplate;
+    private final DatabaseCleanUp databaseCleanUp;
+
+    @Autowired
+    public MemberV1ApiE2ETest(TestRestTemplate testRestTemplate, DatabaseCleanUp databaseCleanUp) {
+        this.testRestTemplate = testRestTemplate;
+        this.databaseCleanUp = databaseCleanUp;
+    }
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("POST /api/v1/users")
+    @Nested
+    class SignUp {
+        @DisplayName("회원 가입이 성공할 경우, 생성된 유저 정보를 응답으로 반환한다.")
+        @Test
+        void returnsCreatedMember_whenSuccessfulSignUp() {
+            String userId = "test";
+            Gender gender = Gender.MALE;
+            String birthdate = "2000-01-01";
+            String email = "test@test.com";
+
+            ParameterizedTypeReference<ApiResponse<MemberV1Dto.MemberResponse>> responseType = new ParameterizedTypeReference<>() {
+            };
+            ResponseEntity<ApiResponse<MemberV1Dto.MemberResponse>> response = testRestTemplate.exchange(ENDPOINT_SIGNUP, HttpMethod.POST, new HttpEntity<>(new MemberV1Dto.SignupRequest(
+                    userId, gender, birthdate, email
+            )), responseType);
+
+            assertTrue(response.getStatusCode().is2xxSuccessful());
+            assertThat(response.getBody().meta().result()).isEqualTo(ApiResponse.Metadata.Result.SUCCESS);
+            assertThat(response.getBody().data().userId()).isEqualTo(userId);
+            assertThat(response.getBody().data().gender()).isEqualTo(gender);
+            assertThat(response.getBody().data().birthdate()).isEqualTo(birthdate);
+            assertThat(response.getBody().data().email()).isEqualTo(email);
+        }
+
+        @DisplayName("회원 가입 시에 성별이 없을 경우, 400 Bad Request 응답을 반환한다.")
+        @Test
+        void returnsBadRequest_whenNotExistGender() {
+            String userId = "test";
+            String birthdate = "2000-01-01";
+            String email = "test@test.com";
+
+            ParameterizedTypeReference<ApiResponse<MemberV1Dto.MemberResponse>> responseType = new ParameterizedTypeReference<>() {
+            };
+            ResponseEntity<ApiResponse<MemberV1Dto.MemberResponse>> response = testRestTemplate.exchange(ENDPOINT_SIGNUP, HttpMethod.POST, new HttpEntity<>(new MemberV1Dto.SignupRequest(
+                    userId, null, birthdate, email
+            )), responseType);
+
+            assertAll(
+                    () -> assertTrue(response.getStatusCode().is4xxClientError()),
+                    () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST),
+                    () -> assertThat(response.getBody().meta().result()).isEqualTo(ApiResponse.Metadata.Result.FAIL)
+            );
+        }
+    }
+
+}

--- a/modules/jpa/build.gradle.kts
+++ b/modules/jpa/build.gradle.kts
@@ -8,6 +8,9 @@ dependencies {
     api("org.springframework.boot:spring-boot-starter-data-jpa")
     // querydsl
     api("com.querydsl:querydsl-jpa::jakarta")
+    annotationProcessor("com.querydsl:querydsl-apt::jakarta")
+    annotationProcessor("jakarta.persistence:jakarta.persistence-api")
+    annotationProcessor("jakarta.annotation:jakarta.annotation-api")
     // jdbc-mysql
     runtimeOnly("com.mysql:mysql-connector-j")
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,4 @@
-rootProject.name = "loopers-java-spring-template"
+rootProject.name = "e-commerce"
 
 include(
     ":apps:commerce-api",


### PR DESCRIPTION
## 📌 Summary
1. 회원 가입 기능 추가
2. 회원 가입 테스트 작성
3. 프로젝트명 및 query dsl 설정 변경

## ✅ Checklist

🔗 통합 테스트

- [x]  회원 가입시 User 저장이 수행된다. ( spy 검증 )
- [x]  이미 가입된 ID 로 회원가입 시도 시, 실패한다.

**🌐 E2E 테스트**

- [x]  회원 가입이 성공할 경우, 생성된 유저 정보를 응답으로 반환한다.
- [x]  회원 가입 시에 성별이 없을 경우, `400 Bad Request` 응답을 반환한다.