### PR TITLE
feat: 보유 포인트 조회 기능 구현 및 테스트 작성

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/points/PointsFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/points/PointsFacade.java
@@ -1,5 +1,6 @@
 package com.loopers.application.points;
 
+import com.loopers.domain.member.MemberModel;
 import com.loopers.domain.member.MemberService;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
@@ -16,5 +17,17 @@ public class PointsFacade {
             throw new CoreException(ErrorType.BAD_REQUEST, "포인트는 0보다 커야 합니다.");
         }
         return memberService.chargePoints(userId, points).getPoints();
+    }
+
+    public Long getPoints(String userId) {
+        try {
+            MemberModel member = memberService.getMember(userId);
+            return member.getPoints();
+        } catch (CoreException e) {
+            if (e.getErrorType() == ErrorType.NOT_FOUND) {
+                return null;
+            }
+            throw e;
+        }
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/member/MemberModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/member/MemberModel.java
@@ -31,6 +31,10 @@ public class MemberModel extends BaseEntity {
     }
 
     public MemberModel(String userId, Gender gender, String birthdate, String email) {
+        this(userId, gender, birthdate, email, 0L);
+    }
+
+    public MemberModel(String userId, Gender gender, String birthdate, String email, Long points) {
         if (userId == null || userId.isBlank()) {
             throw new CoreException(ErrorType.BAD_REQUEST, "이름은 비어있을 수 없습니다.");
         }
@@ -55,14 +59,16 @@ public class MemberModel extends BaseEntity {
         if (!email.matches("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,6}$")) {
             throw new CoreException(ErrorType.BAD_REQUEST, "잘못된 형식의 이메일입니다.");
         }
+        if (points == null || points < 0) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "포인트는 0 이상이어야 합니다.");
+        }
 
         this.userId = userId;
         this.gender = gender;
         this.birthdate = parsedBirthdate;
         this.email = email;
-        this.points = 0L;
+        this.points = points;
     }
-
 
     public String getUserId() {
         return userId;

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/points/PointsV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/points/PointsV1ApiSpec.java
@@ -17,4 +17,12 @@ public interface PointsV1ApiSpec {
             @RequestHeader("X-USER-ID") String userId,
             @RequestBody PointsV1Dto.PointsChargeRequest dto
     );
+
+    @Operation(
+            summary = "보유 포인트 조회",
+            description = "사용자의 보유 포인트를 조회합니다."
+    )
+    ApiResponse<PointsV1Dto.PointsResponse> getMyPoints(
+            @RequestHeader(value = "X-USER-ID", required = false) String userId
+    );
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/points/PointsV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/points/PointsV1Controller.java
@@ -2,7 +2,10 @@ package com.loopers.interfaces.api.points;
 
 import com.loopers.application.points.PointsFacade;
 import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,5 +22,14 @@ public class PointsV1Controller implements PointsV1ApiSpec {
     public ApiResponse<PointsV1Dto.PointsResponse> charge(String userId, PointsV1Dto.PointsChargeRequest dto) {
         Long currentPoints = pointsFacade.chargePoints(userId, dto.amount());
         return ApiResponse.success(new PointsV1Dto.PointsResponse(currentPoints));
+    }
+
+    @GetMapping()
+    @Override
+    public ApiResponse<PointsV1Dto.PointsResponse> getMyPoints(String userId) {
+        if (userId == null || userId.isBlank()) {
+            throw new CoreException(ErrorType.BAD_REQUEST);
+        }
+        return ApiResponse.success(new PointsV1Dto.PointsResponse(pointsFacade.getPoints(userId)));
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/application/member/PointsFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/member/PointsFacadeIntegrationTest.java
@@ -1,7 +1,9 @@
 package com.loopers.application.member;
 
 import com.loopers.application.points.PointsFacade;
+import com.loopers.domain.member.MemberModel;
 import com.loopers.domain.member.MemberService;
+import com.loopers.domain.member.enums.Gender;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import com.loopers.utils.DatabaseCleanUp;
@@ -15,6 +17,9 @@ import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 public class PointsFacadeIntegrationTest {
@@ -46,6 +51,35 @@ public class PointsFacadeIntegrationTest {
             CoreException exception = assertThrows(CoreException.class, () -> pointsFacade.chargePoints(notExistUserId, points));
 
             assertThat(exception.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
+        }
+    }
+
+    @DisplayName("보유 포인트를 조회할 때")
+    @Nested
+    class GetPoints {
+
+        @DisplayName("해당 ID 의 회원이 존재할 경우, 보유 포인트가 반환된다.")
+        @Test
+        void returnsPoints_whenExistUserId() {
+            String userId = "testUser";
+            Long initialPoints = 1000L;
+            doReturn(new MemberModel(userId, Gender.FEMALE, "2000-01-01", "test@test.com", initialPoints)).when(memberService).getMember(userId);
+
+            Long points = pointsFacade.getPoints(userId);
+
+            assertThat(points).isEqualTo(initialPoints);
+        }
+
+        @DisplayName("해당 ID 의 회원이 존재하지 않을 경우, null 이 반환된다.")
+        @Test
+        void returnsNull_whenNotExistUserId() {
+            String notExistUserId = "notTestUser";
+            doThrow(new CoreException(ErrorType.NOT_FOUND))
+                    .when(memberService).getMember(eq(notExistUserId));
+
+            Long points = pointsFacade.getPoints(notExistUserId);
+
+            assertThat(points).isNull();
         }
     }
 }


### PR DESCRIPTION
## 📌 Summary

보유 포인트 조회 기능 구현 및 테스트 작성

## 💬 Review Points

1. RequestHeader가 required일 때 제공 안하면 MissingRequestHeaderException 예외가 발생하는데, advice로 처리하자니 가장 추상화 된 예외인 ServletException을 잡아서 처리해야 하나? 싶어서 저는 required 풀어서 직접 null 체크 했는데 멘토님 의견이 궁금합니다

2. 포인트 조회를 MemberInfo에서 꺼내올 수도 있었을 것 같은데 포인트 파사드에서 처리한 게 좋은 판단이었을까요?

## ✅ Checklist

### 포인트 조회

**🔗 통합 테스트**

- [x]  해당 ID 의 회원이 존재할 경우, 보유 포인트가 반환된다.
- [x]  해당 ID 의 회원이 존재하지 않을 경우, null 이 반환된다.

**🌐 E2E 테스트**

- [x]  포인트 조회에 성공할 경우, 보유 포인트를 응답으로 반환한다.
- [x]  `X-USER-ID` 헤더가 없을 경우, `400 Bad Request` 응답을 반환한다.
