### PR TITLE
[round-3] 도메인 모델링

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/brand/dto/BrandInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/brand/dto/BrandInfo.java
@@ -1,0 +1,19 @@
+package com.loopers.application.brand.dto;
+
+import com.loopers.application.product.dto.ProductInfo;
+import com.loopers.domain.brand.BrandModel;
+import com.loopers.domain.product.ProductModel;
+
+import java.util.List;
+
+public record BrandInfo(Long id, String name, String description, List<ProductInfo> products) {
+
+    public static BrandInfo from(BrandModel brand, List<ProductModel> products) {
+        return new BrandInfo(
+            brand.getId(),
+            brand.getName(),
+            brand.getDescription(),
+            products.stream().map(product -> ProductInfo.from(product, brand)).toList()
+        );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/brand/usecase/query/QueryBrandDetailUseCase.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/brand/usecase/query/QueryBrandDetailUseCase.java
@@ -1,0 +1,52 @@
+package com.loopers.application.brand.usecase.query;
+
+import com.loopers.application.brand.dto.BrandInfo;
+import com.loopers.domain.brand.BrandModel;
+import com.loopers.domain.brand.BrandService;
+import com.loopers.domain.product.ProductModel;
+import com.loopers.domain.product.ProductService;
+import com.loopers.domain.product.spec.ProductSearchConditionFactory;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class QueryBrandDetailUseCase {
+
+    private final BrandService brandService;
+    private final ProductService productService;
+
+    @Transactional(readOnly = true)
+    public Result execute(Query query) {
+        if (query == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "Query cannot be null");
+        }
+
+        BrandModel brand = brandService.getDetail(query.brandId());
+        List<ProductModel> products = productService.search(
+            ProductSearchConditionFactory.buildBrandEqual(brand),
+            PageRequest.of(0, 10)
+        );
+
+        final long displayLimit = 5L;
+        List<ProductModel> rankedProducts = brandService.getRepresentativeProducts(
+            brand,
+            products,
+            displayLimit
+        );
+
+        return new Result(BrandInfo.from(brand, rankedProducts));
+    }
+
+    public record Result(BrandInfo brandInfo) {
+    }
+
+    public record Query(Long brandId) {
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/usecase/command/CommandMarkLikeUseCase.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/usecase/command/CommandMarkLikeUseCase.java
@@ -1,0 +1,39 @@
+package com.loopers.application.like.usecase.command;
+
+import com.loopers.application.member.MemberInfo;
+import com.loopers.domain.like.LikeService;
+import com.loopers.domain.member.MemberModel;
+import com.loopers.domain.member.MemberService;
+import com.loopers.domain.product.ProductModel;
+import com.loopers.domain.product.ProductService;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CommandMarkLikeUseCase {
+
+    private final MemberService memberService;
+    private final ProductService productService;
+    private final LikeService likeService;
+
+    @Transactional
+    void execute(Command command) {
+        if (command == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "Command cannot be null");
+        }
+
+        MemberModel member = memberService.getMember(command.memberInfo.userId());
+        ProductModel product = productService.getDetail(command.productId());
+
+        likeService.like(member, product);
+
+        productService.updateProductLikeCount(product, likeService.getLikeCount(product));
+    }
+
+    public record Command(MemberInfo memberInfo, Long productId) {
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/usecase/command/CommandUnmarkLikeUseCase.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/usecase/command/CommandUnmarkLikeUseCase.java
@@ -1,0 +1,39 @@
+package com.loopers.application.like.usecase.command;
+
+import com.loopers.application.member.MemberInfo;
+import com.loopers.domain.like.LikeService;
+import com.loopers.domain.member.MemberModel;
+import com.loopers.domain.member.MemberService;
+import com.loopers.domain.product.ProductModel;
+import com.loopers.domain.product.ProductService;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CommandUnmarkLikeUseCase {
+
+    private final MemberService memberService;
+    private final ProductService productService;
+    private final LikeService likeService;
+
+    @Transactional
+    void execute(Command command) {
+        if (command == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "Command cannot be null");
+        }
+
+        MemberModel member = memberService.getMember(command.memberInfo.userId());
+        ProductModel product = productService.getDetail(command.productId());
+
+        likeService.unlike(member, product);
+
+        productService.updateProductLikeCount(product, likeService.getLikeCount(product));
+    }
+
+    public record Command(MemberInfo memberInfo, Long productId) {
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/usecase/query/QueryMemberLikedProductsUseCase.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/usecase/query/QueryMemberLikedProductsUseCase.java
@@ -1,0 +1,77 @@
+package com.loopers.application.like.usecase.query;
+
+import com.loopers.application.member.MemberInfo;
+import com.loopers.application.product.dto.ProductInfo;
+import com.loopers.domain.brand.BrandModel;
+import com.loopers.domain.brand.BrandService;
+import com.loopers.domain.like.LikeModel;
+import com.loopers.domain.like.LikeService;
+import com.loopers.domain.member.MemberModel;
+import com.loopers.domain.member.MemberService;
+import com.loopers.domain.product.ProductModel;
+import com.loopers.domain.product.ProductService;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class QueryMemberLikedProductsUseCase {
+
+    private final MemberService memberService;
+    private final ProductService productService;
+    private final BrandService brandService;
+    private final LikeService likeService;
+
+    @Transactional(readOnly = true)
+    public Result execute(Query query) {
+        if (query == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "Query cannot be null");
+        }
+
+        MemberModel member = memberService.getMember(query.memberInfo().userId());
+
+        Set<Long> likedProductIds = likeService.getLikes(member, query.pageRequest()).stream().map(LikeModel::getProductId).collect(Collectors.toSet());
+        List<ProductModel> products = productService.getProducts(likedProductIds);
+
+        Map<Long, BrandModel> brandMap = brandService.getBrands(
+                products.stream().map(ProductModel::getBrandId).collect(Collectors.toSet())
+            )
+            .stream()
+            .collect(Collectors.toMap(BrandModel::getId, brandModel -> brandModel));
+
+        Page<ProductInfo> result = new PageImpl<>(
+            products.stream()
+                .map(product -> {
+                    BrandModel brand = brandMap.get(product.getBrandId());
+                    return ProductInfo.from(product, brand);
+                })
+                .collect(Collectors.toList()),
+            query.pageRequest(),
+            likeService.countLikedProducts(member)
+        );
+
+        return new Result(query.memberInfo(), result);
+    }
+
+    public record Result(MemberInfo member, Page<ProductInfo> products) {
+    }
+
+    public record Query(MemberInfo memberInfo, PageRequest pageRequest) {
+        public Query {
+            if (memberInfo == null || pageRequest == null) {
+                throw new CoreException(ErrorType.BAD_REQUEST, "MemberInfo and PageRequest cannot be null");
+            }
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/orders/dto/OrderInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/orders/dto/OrderInfo.java
@@ -1,0 +1,26 @@
+package com.loopers.application.orders.dto;
+
+import com.loopers.domain.orders.OrdersModel;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public record OrderInfo(Long memberId, BigDecimal totalPrice, String status, List<OrderItemInfo> items) {
+
+    public OrderInfo {
+        if (memberId == null || totalPrice == null || status == null || status.isBlank() || items == null || items.isEmpty()) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "All fields must be provided and items cannot be empty");
+        }
+    }
+
+    public static OrderInfo from(OrdersModel order) {
+        return new OrderInfo(
+            order.getMemberId(),
+            order.getTotalPrice().getAmount(),
+            order.getStatus().name(),
+            order.getItems().stream().map(OrderItemInfo::from).toList()
+        );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/orders/dto/OrderItemInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/orders/dto/OrderItemInfo.java
@@ -1,0 +1,25 @@
+package com.loopers.application.orders.dto;
+
+import com.loopers.domain.orders.OrderItemModel;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+
+import java.math.BigDecimal;
+
+public record OrderItemInfo(Long productId, String productName, BigDecimal price, Long quantity) {
+
+    public OrderItemInfo {
+        if (productId == null || productName == null || productName.isBlank() || price == null || quantity == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "All fields must be provided");
+        }
+    }
+
+    public static OrderItemInfo from(OrderItemModel item) {
+        return new OrderItemInfo(
+            item.getProductSnapshot().getProductId(),
+            item.getProductSnapshot().getName(),
+            item.getProductSnapshot().getPrice().getAmount(),
+            item.getQuantity()
+        );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/orders/usecase/command/CommandOrderUseCase.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/orders/usecase/command/CommandOrderUseCase.java
@@ -1,0 +1,66 @@
+package com.loopers.application.orders.usecase.command;
+
+import com.loopers.application.member.MemberInfo;
+import com.loopers.application.orders.dto.OrderInfo;
+import com.loopers.domain.member.MemberModel;
+import com.loopers.domain.member.MemberService;
+import com.loopers.domain.orders.ExternalServiceOutputPort;
+import com.loopers.domain.orders.OrderService;
+import com.loopers.domain.orders.OrdersModel;
+import com.loopers.domain.product.ProductModel;
+import com.loopers.domain.product.ProductService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.util.Pair;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CommandOrderUseCase {
+
+    private final MemberService memberService;
+    private final ProductService productService;
+    private final OrderService orderService;
+    private final ExternalServiceOutputPort deliveryClient;
+
+    @Transactional()
+    public Result execute(Command command) {
+        MemberModel member = memberService.getMember(command.memberInfo().userId());
+
+        List<Pair<ProductModel, Long>> items = new ArrayList<>();
+        BigDecimal totalPrice = BigDecimal.ZERO;
+
+        // 각 주문 상품 재고 차감 및 가격 합산
+        for (int i = 0; i < command.productIds().size(); i++) {
+            Long productId = command.productIds().get(i);
+            long quantity = command.quantities().get(i);
+
+            ProductModel product = productService.getDetail(productId);
+            productService.decreaseStock(product, quantity);
+            items.add(Pair.of(product, quantity));
+
+            totalPrice = totalPrice.add(product.getPrice().multiply(quantity).getAmount());
+        }
+
+        // 포인트 차감
+        memberService.payment(member, totalPrice);
+
+        // 주문 상품 정보 저장
+        OrdersModel order = orderService.order(member, items);
+
+        // 주문 정보 전송
+        deliveryClient.send(order);
+
+        return new Result(OrderInfo.from(order));
+    }
+
+    public record Command(MemberInfo memberInfo, List<Long> productIds, List<Long> quantities) {
+    }
+
+    public record Result(OrderInfo orderInfo) {
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/orders/usecase/query/QueryMemberOrdersUseCase.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/orders/usecase/query/QueryMemberOrdersUseCase.java
@@ -1,0 +1,41 @@
+package com.loopers.application.orders.usecase.query;
+
+import com.loopers.application.member.MemberInfo;
+import com.loopers.application.orders.dto.OrderInfo;
+import com.loopers.domain.member.MemberModel;
+import com.loopers.domain.member.MemberService;
+import com.loopers.domain.orders.OrderService;
+import com.loopers.domain.orders.OrdersModel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class QueryMemberOrdersUseCase {
+
+    private final OrderService orderService;
+    private final MemberService memberService;
+
+    @Transactional(readOnly = true)
+    public Result execute(Query query) {
+        MemberModel member = memberService.getMember(query.memberInfo().userId());
+
+        List<OrdersModel> orders = orderService.getOrders(member);
+
+        return new Result(
+            orders.stream()
+                .map(OrderInfo::from)
+                .toList()
+        );
+    }
+
+    public record Query(MemberInfo memberInfo) {
+    }
+
+    public record Result(List<OrderInfo> orders) {
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/orders/usecase/query/QueryOrderDetailUseCase.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/orders/usecase/query/QueryOrderDetailUseCase.java
@@ -1,0 +1,40 @@
+package com.loopers.application.orders.usecase.query;
+
+import com.loopers.application.member.MemberInfo;
+import com.loopers.application.orders.dto.OrderInfo;
+import com.loopers.domain.member.MemberModel;
+import com.loopers.domain.member.MemberService;
+import com.loopers.domain.orders.OrderService;
+import com.loopers.domain.orders.OrdersModel;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class QueryOrderDetailUseCase {
+
+    private final OrderService orderService;
+    private final MemberService memberService;
+
+    @Transactional(readOnly = true)
+    public Result execute(Query query) {
+        MemberModel member = memberService.getMember(query.memberInfo().userId());
+
+        OrdersModel order = orderService.getDetail(query.orderId());
+
+        if (!order.getMemberId().equals(query.memberInfo().id())) {
+            throw new CoreException(ErrorType.FORBIDDEN, "다른 사용자의 주문입니다.");
+        }
+
+        return new Result(OrderInfo.from(order));
+    }
+
+    public record Query(Long orderId, MemberInfo memberInfo) {
+    }
+
+    public record Result(OrderInfo orderInfo) {
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/dto/ProductInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/dto/ProductInfo.java
@@ -1,0 +1,20 @@
+package com.loopers.application.product.dto;
+
+import com.loopers.domain.brand.BrandModel;
+import com.loopers.domain.product.ProductModel;
+
+import java.math.BigDecimal;
+
+public record ProductInfo(Long id, String name, BigDecimal price, Long stock, long likeCount, String brandName) {
+
+    public static ProductInfo from(ProductModel productModel, BrandModel brandModel) {
+        return new ProductInfo(
+            productModel.getId(),
+            productModel.getName(),
+            productModel.getPrice().getAmount(),
+            productModel.getStock().getQuantity(),
+            productModel.getLikeCount(),
+            brandModel.getName()
+        );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/usecase/query/QueryPagedProductsUseCase.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/usecase/query/QueryPagedProductsUseCase.java
@@ -1,0 +1,82 @@
+package com.loopers.application.product.usecase.query;
+
+import com.loopers.application.product.dto.ProductInfo;
+import com.loopers.domain.brand.BrandModel;
+import com.loopers.domain.brand.BrandService;
+import com.loopers.domain.product.ProductModel;
+import com.loopers.domain.product.ProductService;
+import com.loopers.domain.product.spec.ProductSearchConditionFactory;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class QueryPagedProductsUseCase {
+
+    private final ProductService productService;
+    private final BrandService brandService;
+
+    @Transactional(readOnly = true)
+    public Result execute(Query query) {
+        if (query == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "Query cannot be null");
+        }
+
+        if (query.brandId == null) {
+            List<ProductModel> products = productService.search(
+                ProductSearchConditionFactory.buildNoCondition(),
+                query.pageRequest()
+            );
+
+            long totalCount = productService.countAll(ProductSearchConditionFactory.buildNoCondition());
+
+            Map<Long, BrandModel> brandMap = brandService.getBrands(
+                    products.stream().map(ProductModel::getBrandId).collect(Collectors.toSet())
+                )
+                .stream()
+                .collect(Collectors.toMap(BrandModel::getId, brandModel -> brandModel));
+
+            return new Result(new PageImpl<>(
+                products.stream().map(product -> ProductInfo.from(product, brandMap.get(product.getBrandId()))).toList(),
+                query.pageRequest,
+                totalCount
+            ));
+        }
+
+        BrandModel brand = brandService.getDetail(query.brandId());
+
+        List<ProductInfo> products = productService.search(
+                ProductSearchConditionFactory.buildBrandEqual(brand),
+                query.pageRequest()
+            )
+            .stream()
+            .map(product -> ProductInfo.from(product, brand))
+            .toList();
+
+        long totalCount = productService.countAll(ProductSearchConditionFactory.buildNoCondition());
+
+        return new Result(new PageImpl<>(products, query.pageRequest, totalCount));
+    }
+
+    public record Result(Page<ProductInfo> products) {
+    }
+
+    public record Query(Long brandId, PageRequest pageRequest) {
+        public Query {
+            if (pageRequest == null) {
+                throw new CoreException(ErrorType.BAD_REQUEST, "Page Request cannot be null");
+            }
+        }
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/usecase/query/QueryProductDetailUseCase.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/usecase/query/QueryProductDetailUseCase.java
@@ -1,0 +1,37 @@
+package com.loopers.application.product.usecase.query;
+
+import com.loopers.application.product.dto.ProductInfo;
+import com.loopers.domain.brand.BrandService;
+import com.loopers.domain.product.ProductService;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class QueryProductDetailUseCase {
+
+    private final ProductService productService;
+    private final BrandService brandService;
+
+    @Transactional(readOnly = true)
+    public Result execute(Query query) {
+        if (query == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "Query cannot be null");
+        }
+
+        var product = productService.getDetail(query.productId());
+        var brand = brandService.getDetail(product.getBrandId());
+
+        return new Result(ProductInfo.from(product, brand));
+    }
+
+    public record Result(ProductInfo product) {
+    }
+
+    public record Query(Long productId) {
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/brand/BrandModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/brand/BrandModel.java
@@ -1,0 +1,33 @@
+package com.loopers.domain.brand;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "brand")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BrandModel extends BaseEntity {
+
+    @Getter
+    private String name;
+
+    @Getter
+    private String description;
+
+    public BrandModel(String name, String description) {
+        if (name == null || name.isBlank()) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "Brand name cannot be null or blank.");
+        }
+        if (description != null && description.isBlank()) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "Brand description cannot be blank.");
+        }
+        this.name = name;
+        this.description = description;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/brand/BrandRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/brand/BrandRepository.java
@@ -1,0 +1,11 @@
+package com.loopers.domain.brand;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+public interface BrandRepository {
+    Optional<BrandModel> find(Long brandId);
+
+    List<BrandModel> findAll(Set<Long> brandIds);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/brand/BrandService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/brand/BrandService.java
@@ -1,0 +1,49 @@
+package com.loopers.domain.brand;
+
+import com.loopers.domain.product.ProductModel;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+
+@Component
+@RequiredArgsConstructor
+public class BrandService {
+
+    private final BrandRepository brandRepository;
+
+    public BrandModel getDetail(Long brandId) {
+        if (brandId == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "Brand ID cannot be null");
+        }
+
+        Optional<BrandModel> brand = brandRepository.find(brandId);
+        if (brand.isEmpty()) {
+            throw new CoreException(ErrorType.NOT_FOUND, "Brand not found with ID: " + brandId);
+        }
+
+        return brand.get();
+    }
+
+    public List<BrandModel> getBrands(Set<Long> brandIds) {
+        if (brandIds == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "Brand IDs cannot be null");
+        }
+
+        if (brandIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return brandRepository.findAll(brandIds);
+    }
+
+    public List<ProductModel> getRepresentativeProducts(BrandModel brandModel, List<ProductModel> products, long limit) {
+        return products.stream()
+            .filter(product -> product.getBrandId().equals(brandModel.getId()))
+            .sorted(Comparator.comparingLong(ProductModel::getLikeCount).reversed())
+            .limit(limit)
+            .toList();
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeId.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeId.java
@@ -1,0 +1,35 @@
+package com.loopers.domain.like;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LikeId implements Serializable {
+    private Long memberId;
+    private Long productId;
+
+    private LikeId(Long memberId, Long productId) {
+        this.memberId = memberId;
+        this.productId = productId;
+    }
+
+    public static LikeId of(Long memberId, Long productId) {
+        return new LikeId(memberId, productId);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        LikeId likeId = (LikeId) o;
+        return Objects.equals(memberId, likeId.memberId) && Objects.equals(productId, likeId.productId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(memberId, productId);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeModel.java
@@ -1,0 +1,40 @@
+package com.loopers.domain.like;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.ZonedDateTime;
+
+@Entity
+@Table(name = "likes")
+@IdClass(LikeId.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LikeModel {
+
+    @Id
+    @Getter
+    private Long memberId;
+
+    @Id
+    @Getter
+    private Long productId;
+
+    private ZonedDateTime createdAt;
+
+    public LikeModel(Long memberId, Long productId) {
+        if (memberId == null || productId == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "Member ID and Product ID cannot be null.");
+        }
+
+        this.memberId = memberId;
+        this.productId = productId;
+        this.createdAt = ZonedDateTime.now();
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeRepository.java
@@ -1,0 +1,21 @@
+package com.loopers.domain.like;
+
+import com.loopers.domain.member.MemberModel;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface LikeRepository {
+    Optional<LikeModel> find(Long memberId, Long productId);
+
+    LikeModel save(LikeModel likeModel);
+
+    void delete(LikeModel likeModel);
+
+    long getProductLikeCount(Long productId);
+
+    List<LikeModel> search(MemberModel member, Pageable pageable);
+
+    long countMemberLikedProducts(Long memberId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
@@ -1,0 +1,61 @@
+package com.loopers.domain.like;
+
+import com.loopers.domain.member.MemberModel;
+import com.loopers.domain.product.ProductModel;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class LikeService {
+
+    private final LikeRepository likeRepository;
+
+    public void like(MemberModel member, ProductModel product) {
+        if (member == null || product == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "Member and Product cannot be null");
+        }
+
+        Optional<LikeModel> like = likeRepository.find(member.getId(), product.getId());
+        if (like.isEmpty()) {
+            likeRepository.save(new LikeModel(member.getId(), product.getId()));
+        }
+    }
+
+    public void unlike(MemberModel member, ProductModel product) {
+        if (member == null || product == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "Member and Product cannot be null");
+        }
+
+        Optional<LikeModel> like = likeRepository.find(member.getId(), product.getId());
+        like.ifPresent(likeRepository::delete);
+    }
+
+    public long getLikeCount(ProductModel product) {
+        if (product == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "Product cannot be null");
+        }
+
+        return likeRepository.getProductLikeCount(product.getId());
+    }
+
+    public List<LikeModel> getLikes(MemberModel member, Pageable pageable) {
+        if (member == null || pageable == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "Member and Pageable cannot be null");
+        }
+        return likeRepository.search(member, pageable);
+    }
+
+    public long countLikedProducts(MemberModel member) {
+        if (member == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "Member cannot be null");
+        }
+        return likeRepository.countMemberLikedProducts(member.getId());
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/member/MemberModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/member/MemberModel.java
@@ -97,4 +97,14 @@ public class MemberModel extends BaseEntity {
         this.points += amount;
         return this.points;
     }
+
+    public void usePoints(long amount) {
+        if (amount <= 0) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "사용 금액은 0보다 커야 합니다.");
+        }
+        if (this.points < amount) {
+            throw new CoreException(ErrorType.CONFLICT, "포인트가 부족합니다.");
+        }
+        this.points -= amount;
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/member/MemberService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/member/MemberService.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
 import java.text.MessageFormat;
 
 @RequiredArgsConstructor
@@ -17,10 +18,10 @@ public class MemberService {
     @Transactional(readOnly = true)
     public MemberModel getMember(String userId) {
         return memberRepository.findByUserId(userId)
-                .orElseThrow(() -> new CoreException(
-                        ErrorType.NOT_FOUND,
-                        MessageFormat.format("[userId = {0}] 회원을 찾을 수 없습니다.", userId)
-                ));
+            .orElseThrow(() -> new CoreException(
+                ErrorType.NOT_FOUND,
+                MessageFormat.format("[userId = {0}] 회원을 찾을 수 없습니다.", userId)
+            ));
     }
 
     @Transactional()
@@ -31,11 +32,28 @@ public class MemberService {
     @Transactional()
     public MemberModel chargePoints(String userId, Long points) {
         MemberModel member = memberRepository.findByUserId(userId)
-                .orElseThrow(() -> new CoreException(
-                        ErrorType.NOT_FOUND,
-                        MessageFormat.format("[userId = {0}] 회원을 찾을 수 없습니다.", userId)
-                ));
+            .orElseThrow(() -> new CoreException(
+                ErrorType.NOT_FOUND,
+                MessageFormat.format("[userId = {0}] 회원을 찾을 수 없습니다.", userId)
+            ));
         member.chargePoints(points);
         return memberRepository.update(member);
+    }
+
+    @Transactional()
+    public void payment(MemberModel member, BigDecimal totalPrice) {
+        if (member == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "Member cannot be null.");
+        }
+        if (totalPrice == null || totalPrice.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "Total price must be greater than zero.");
+        }
+
+        if (member.getPoints() < totalPrice.longValue()) {
+            throw new CoreException(ErrorType.CONFLICT, "Insufficient points for payment.");
+        }
+
+        member.usePoints(totalPrice.longValue());
+        memberRepository.update(member);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/orders/ExternalServiceOutputPort.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/orders/ExternalServiceOutputPort.java
@@ -1,0 +1,5 @@
+package com.loopers.domain.orders;
+
+public interface ExternalServiceOutputPort {
+    void send(OrdersModel order);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/orders/OrderItemModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/orders/OrderItemModel.java
@@ -1,0 +1,40 @@
+package com.loopers.domain.orders;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.domain.orders.vo.ProductSnapshot;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "order_item")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrderItemModel extends BaseEntity {
+
+    @ManyToOne()
+    @JoinColumn(name = "orders_id")
+    private OrdersModel orders;
+
+    @Embedded
+    @Getter
+    private ProductSnapshot productSnapshot;
+
+    @Getter
+    private Long quantity;
+
+    public OrderItemModel(OrdersModel orders, ProductSnapshot productSnapshot, Long quantity) {
+        if (orders == null || productSnapshot == null || quantity == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "Orders, ProductSnapshot, and Quantity cannot be null.");
+        }
+        this.orders = orders;
+        this.productSnapshot = productSnapshot;
+        this.quantity = quantity;
+    }
+
+    void setOrders(OrdersModel orders) {
+        this.orders = orders;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/orders/OrderRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/orders/OrderRepository.java
@@ -1,0 +1,15 @@
+package com.loopers.domain.orders;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+public interface OrderRepository {
+    OrdersModel save(OrdersModel order);
+
+    List<OrderItemModel> saveAll(Set<OrderItemModel> items);
+
+    List<OrdersModel> search(Long memberId);
+
+    Optional<OrdersModel> find(Long orderId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/orders/OrderService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/orders/OrderService.java
@@ -1,0 +1,69 @@
+package com.loopers.domain.orders;
+
+import com.loopers.domain.member.MemberModel;
+import com.loopers.domain.orders.vo.Price;
+import com.loopers.domain.orders.vo.ProductSnapshot;
+import com.loopers.domain.product.ProductModel;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.util.Pair;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class OrderService {
+
+    private final OrderRepository orderRepository;
+
+    public OrdersModel order(MemberModel member, List<Pair<ProductModel, Long>> products) {
+        if (member == null || products == null || products.isEmpty()) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "Member and Products cannot be null or empty.");
+        }
+
+        Price totalPrice = Price.of(products.stream()
+            .map(pair -> pair.getFirst().getPrice().multiply(pair.getSecond()).getAmount())
+            .reduce(BigDecimal.ZERO, BigDecimal::add));
+
+        OrdersModel order = new OrdersModel(member.getId(), totalPrice);
+
+        for (Pair<ProductModel, Long> pair : products) {
+            ProductModel product = pair.getFirst();
+            Long quantity = pair.getSecond();
+
+            if (product == null || quantity == null || quantity <= 0) {
+                throw new CoreException(ErrorType.BAD_REQUEST, "Product and quantity must be valid.");
+            }
+
+            OrderItemModel item = new OrderItemModel(
+                order,
+                ProductSnapshot.of(product.getId(), product.getName(), Price.of(product.getPrice().getAmount())),
+                quantity
+            );
+            order.addItem(item);
+        }
+
+        OrdersModel savedOrder = orderRepository.save(order);
+        orderRepository.saveAll(order.getItems());
+        return savedOrder;
+    }
+
+    public List<OrdersModel> getOrders(MemberModel member) {
+        if (member == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "Member cannot be null.");
+        }
+        return orderRepository.search(member.getId());
+    }
+
+    public OrdersModel getDetail(Long orderId) {
+        if (orderId == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "Order ID cannot be null.");
+        }
+
+        return orderRepository.find(orderId)
+            .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "Order not found."));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/orders/OrdersModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/orders/OrdersModel.java
@@ -1,0 +1,54 @@
+package com.loopers.domain.orders;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.domain.orders.enums.OrderStatus;
+import com.loopers.domain.orders.vo.Price;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "orders")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrdersModel extends BaseEntity {
+
+    @Getter
+    private Long memberId;
+
+    @Embedded
+    @AttributeOverride(name = "amount", column = @Column(name = "total_price"))
+    @Getter
+    private Price totalPrice;
+
+    @Enumerated(EnumType.STRING)
+    @Getter
+    private OrderStatus status;
+
+    @OneToMany(mappedBy = "orders", fetch = FetchType.LAZY)
+    @Getter
+    private Set<OrderItemModel> items = new LinkedHashSet<>();
+
+    public OrdersModel(Long memberId, Price totalPrice) {
+        if (memberId == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "Member ID cannot be null.");
+        }
+        if (totalPrice == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "Total price cannot be null.");
+        }
+
+        this.memberId = memberId;
+        this.totalPrice = totalPrice;
+        this.status = OrderStatus.NOT_PAID;
+    }
+
+    public void addItem(OrderItemModel item) {
+        items.add(item);
+        item.setOrders(this);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/orders/enums/OrderStatus.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/orders/enums/OrderStatus.java
@@ -1,0 +1,7 @@
+package com.loopers.domain.orders.enums;
+
+public enum OrderStatus {
+    NOT_PAID,
+    PAID,
+    CANCELED,
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/orders/vo/Price.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/orders/vo/Price.java
@@ -1,0 +1,51 @@
+package com.loopers.domain.orders.vo;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.Embeddable;
+import lombok.Getter;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+
+@Embeddable
+public class Price implements Serializable {
+
+    public static final Price ZERO = new Price(BigDecimal.ZERO);
+
+    @Getter
+    private BigDecimal amount;
+
+    protected Price() {
+    }
+
+    private Price(BigDecimal amount) {
+        if (amount == null || amount.compareTo(BigDecimal.ZERO) < 0) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "가격은 null 이거나 음수일 수 없습니다.");
+        }
+        this.amount = amount;
+    }
+
+    public static Price of(BigDecimal amount) {
+        return new Price(amount);
+    }
+
+    public Price add(Price other) {
+        if (other == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "추가할 가격은 null 일 수 없습니다.");
+        }
+        return new Price(this.amount.add(other.amount));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        Price price = (Price) o;
+        return amount.equals(price.amount);
+    }
+
+    @Override
+    public int hashCode() {
+        return amount.hashCode();
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/orders/vo/ProductSnapshot.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/orders/vo/ProductSnapshot.java
@@ -1,0 +1,51 @@
+package com.loopers.domain.orders.vo;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductSnapshot implements Serializable {
+
+    @Column(name = "product_id")
+    @Getter
+    private Long productId;
+
+    @Column(name = "product_name")
+    @Getter
+    private String name;
+
+    @Embedded
+    @AttributeOverride(name = "amount", column = @Column(name = "product_price"))
+    @Getter
+    private Price price;
+
+    private ProductSnapshot(Long productId, String name, Price price) {
+        if (productId == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "Product ID cannot be null");
+        }
+        if (name == null || name.isEmpty()) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "Product name cannot be null or empty");
+        }
+        if (price == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "Product price cannot be null");
+        }
+
+        this.productId = productId;
+        this.name = name;
+        this.price = price;
+    }
+
+    public static ProductSnapshot of(Long productId, String name, Price price) {
+        return new ProductSnapshot(productId, name, price);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductModel.java
@@ -1,0 +1,68 @@
+package com.loopers.domain.product;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.domain.product.vo.Price;
+import com.loopers.domain.product.vo.Stock;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Table(name = "product")
+public class ProductModel extends BaseEntity {
+
+    @Getter
+    private String name;
+
+    @Embedded
+    @AttributeOverride(name = "amount", column = @Column(name = "price"))
+    @Getter
+    private Price price;
+
+    @Embedded
+    @AttributeOverride(name = "quantity", column = @Column(name = "stock"))
+    @Getter
+    private Stock stock;
+
+    @Getter
+    private Long brandId;
+
+    @Getter
+    private long likeCount;
+
+    protected ProductModel() {
+    }
+
+    public ProductModel(String name, Price price, Stock stock, Long brandId) {
+        if (name == null || name.isBlank()) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "Product name cannot be null or blank.");
+        }
+        if (price == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "Price cannot be null.");
+        }
+        if (stock == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "Stock cannot be null.");
+        }
+        if (brandId == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "Brand ID cannot be null.");
+        }
+
+        this.name = name;
+        this.price = price;
+        this.stock = stock;
+        this.brandId = brandId;
+        this.likeCount = 0L;
+    }
+
+    public void decreaseStock(long quantity) {
+        this.stock = this.stock.deduct(quantity);
+    }
+
+    public void updateLikeCount(long likeCount) {
+        if (likeCount < 0) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "Like count cannot be negative.");
+        }
+        this.likeCount = likeCount;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
@@ -1,0 +1,20 @@
+package com.loopers.domain.product;
+
+import com.loopers.domain.product.spec.ProductSearchCondition;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+public interface ProductRepository {
+    List<ProductModel> search(ProductSearchCondition condition, Pageable pageable);
+
+    long getTotalAmount(ProductSearchCondition condition);
+
+    List<ProductModel> findAll(Set<Long> productIds);
+
+    Optional<ProductModel> find(Long productId);
+
+    ProductModel save(ProductModel product);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
@@ -1,0 +1,82 @@
+package com.loopers.domain.product;
+
+import com.loopers.domain.product.spec.ProductSearchCondition;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class ProductService {
+
+    private final ProductRepository productRepository;
+
+    public List<ProductModel> search(ProductSearchCondition condition, Pageable pageable) {
+        if (condition == null || pageable == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "Search condition or pageable cannot be null");
+        }
+
+        return productRepository.search(condition, pageable);
+    }
+
+    public long countAll(ProductSearchCondition condition) {
+        if (condition == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "Search condition cannot be null");
+        }
+
+        return productRepository.getTotalAmount(condition);
+    }
+
+    public List<ProductModel> getProducts(Set<Long> productIds) {
+        if (productIds == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "Product IDs cannot be null");
+        }
+
+        if (productIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return productRepository.findAll(productIds);
+    }
+
+    public ProductModel getDetail(Long productId) {
+        if (productId == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "Product ID cannot be null");
+        }
+
+        Optional<ProductModel> product = productRepository.find(productId);
+        if (product.isEmpty()) {
+            throw new CoreException(ErrorType.NOT_FOUND, "Product not found with ID: " + productId);
+        }
+
+        return product.get();
+    }
+
+    public ProductModel updateProductLikeCount(ProductModel product, Long likeCount) {
+        if (product == null || likeCount == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "Product and like count cannot be null");
+        }
+
+        product.updateLikeCount(likeCount);
+        return productRepository.save(product);
+    }
+
+    public void decreaseStock(ProductModel product, long quantity) {
+        if (product == null || quantity <= 0) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "Product cannot be null and quantity must be greater than zero");
+        }
+        if (product.getStock().getQuantity() < quantity) {
+            throw new CoreException(ErrorType.CONFLICT, "Insufficient stock for product ID: " + product.getId());
+        }
+
+        product.decreaseStock(quantity);
+        productRepository.save(product);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/enums/OrderBy.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/enums/OrderBy.java
@@ -1,0 +1,29 @@
+package com.loopers.domain.product.enums;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+
+public enum OrderBy {
+    LATEST("latest"),
+    PRICE("price"),
+    LIKES("likes");
+
+    private final String property;
+
+    OrderBy(String value) {
+        this.property = value;
+    }
+
+    public static OrderBy fromValue(String value) {
+        for (OrderBy orderBy : OrderBy.values()) {
+            if (orderBy.property.equalsIgnoreCase(value)) {
+                return orderBy;
+            }
+        }
+        throw new CoreException(ErrorType.BAD_REQUEST, "Invalid property");
+    }
+
+    public String getProperty() {
+        return property;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/spec/BrandEqualSpecification.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/spec/BrandEqualSpecification.java
@@ -1,0 +1,26 @@
+package com.loopers.domain.product.spec;
+
+import com.loopers.domain.brand.BrandModel;
+import com.loopers.domain.product.QProductModel;
+import com.loopers.support.Specification;
+import com.querydsl.core.types.dsl.BooleanExpression;
+
+public class BrandEqualSpecification implements Specification<QProductModel> {
+
+    private final BrandModel brand;
+
+    private BrandEqualSpecification(BrandModel brand) {
+        this.brand = brand;
+    }
+
+    public static BrandEqualSpecification of(BrandModel brand) {
+        return new BrandEqualSpecification(brand);
+    }
+
+    @Override
+    public BooleanExpression isSatisfiedBy(QProductModel productModel) {
+        if (brand == null) return null;
+        return productModel.brandId.eq(brand.getId());
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/spec/ProductSearchCondition.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/spec/ProductSearchCondition.java
@@ -1,0 +1,15 @@
+package com.loopers.domain.product.spec;
+
+import com.loopers.domain.brand.BrandModel;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder(access = AccessLevel.PACKAGE)
+public class ProductSearchCondition {
+
+    @Getter
+    private BrandModel brand;
+
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/spec/ProductSearchConditionFactory.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/spec/ProductSearchConditionFactory.java
@@ -1,0 +1,17 @@
+package com.loopers.domain.product.spec;
+
+import com.loopers.domain.brand.BrandModel;
+
+public class ProductSearchConditionFactory {
+
+    public static ProductSearchCondition buildNoCondition() {
+        return ProductSearchCondition.builder()
+                .build();
+    }
+
+    public static ProductSearchCondition buildBrandEqual(BrandModel brand) {
+        return ProductSearchCondition.builder()
+                .brand(brand)
+                .build();
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/vo/Price.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/vo/Price.java
@@ -1,0 +1,69 @@
+package com.loopers.domain.product.vo;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.Embeddable;
+import lombok.Getter;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+
+@Embeddable
+public class Price implements Serializable {
+
+    public static final Price ZERO = new Price(BigDecimal.ZERO);
+
+    @Getter
+    private BigDecimal amount;
+
+    protected Price() {
+    }
+
+    private Price(BigDecimal amount) {
+        if (amount == null || amount.compareTo(BigDecimal.ZERO) < 0) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "가격은 null 이거나 음수일 수 없습니다.");
+        }
+        this.amount = amount;
+    }
+
+    public static Price of(BigDecimal amount) {
+        return new Price(amount);
+    }
+
+    public Price add(Price other) {
+        if (other == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "추가할 가격은 null 일 수 없습니다.");
+        }
+        return new Price(this.amount.add(other.amount));
+    }
+
+    public Price subtract(Price other) {
+        if (other == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "감소할 가격은 null 일 수 없습니다.");
+        }
+        if (this.amount.compareTo(other.amount) < 0) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "가격이 부족합니다.");
+        }
+        return new Price(this.amount.subtract(other.amount));
+    }
+
+    public Price multiply(long multiplier) {
+        if (multiplier < 0) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "곱할 수는 음수가 될 수 없습니다.");
+        }
+        return Price.of(this.amount.multiply(BigDecimal.valueOf(multiplier)));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        Price price = (Price) o;
+        return amount.equals(price.amount);
+    }
+
+    @Override
+    public int hashCode() {
+        return amount.hashCode();
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/vo/Stock.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/vo/Stock.java
@@ -1,0 +1,54 @@
+package com.loopers.domain.product.vo;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.Embeddable;
+import lombok.Getter;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+@Embeddable
+public class Stock implements Serializable {
+
+    public static final Stock ZERO = new Stock(0L);
+
+    @Getter
+    private long quantity;
+
+    protected Stock() {
+    }
+
+    private Stock(long quantity) {
+        if (quantity < 0) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "재고는 음수일 수 없습니다.");
+        }
+        this.quantity = quantity;
+    }
+
+    public static Stock of(long quantity) {
+        return new Stock(quantity);
+    }
+
+    public Stock deduct(long quantity) {
+        if (quantity < 0) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "감소할 재고 수량은 음수일 수 없습니다.");
+        }
+        if (this.quantity < quantity) {
+            throw new CoreException(ErrorType.CONFLICT, "재고가 부족합니다.");
+        }
+        return new Stock(this.quantity - quantity);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        Stock stock = (Stock) o;
+        return Objects.equals(quantity, stock.quantity);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(quantity);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/brand/BrandRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/brand/BrandRepositoryImpl.java
@@ -1,0 +1,52 @@
+package com.loopers.infrastructure.brand;
+
+import com.loopers.domain.brand.BrandModel;
+import com.loopers.domain.brand.BrandRepository;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.loopers.domain.brand.QBrandModel.brandModel;
+
+
+@Repository
+@RequiredArgsConstructor
+public class BrandRepositoryImpl implements BrandRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<BrandModel> find(Long brandId) {
+        if (brandId == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "Product ID cannot be null");
+        }
+
+        return Optional.ofNullable(
+            queryFactory.selectFrom(brandModel)
+                .where(brandModel.id.eq(brandId))
+                .fetchOne()
+        );
+    }
+
+    @Override
+    public List<BrandModel> findAll(Set<Long> brandIds) {
+        if (brandIds == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "Brand IDs cannot be null");
+        }
+
+        if (brandIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return queryFactory.selectFrom(brandModel)
+            .where(brandModel.id.in(brandIds))
+            .fetch();
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeJpaRepository.java
@@ -1,0 +1,8 @@
+package com.loopers.infrastructure.like;
+
+import com.loopers.domain.like.LikeId;
+import com.loopers.domain.like.LikeModel;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LikeJpaRepository extends JpaRepository<LikeModel, LikeId> {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeRepositoryImpl.java
@@ -1,0 +1,69 @@
+package com.loopers.infrastructure.like;
+
+import com.loopers.domain.like.LikeModel;
+import com.loopers.domain.like.LikeRepository;
+import com.loopers.domain.member.MemberModel;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.loopers.domain.like.QLikeModel.likeModel;
+
+@Repository
+@RequiredArgsConstructor
+public class LikeRepositoryImpl implements LikeRepository {
+
+    private final LikeJpaRepository likeJpaRepository;
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<LikeModel> find(Long memberId, Long productId) {
+        return Optional.ofNullable(
+            queryFactory.selectFrom(likeModel)
+                .where(likeModel.memberId.eq(memberId).and(likeModel.productId.eq(productId)))
+                .fetchOne()
+        );
+    }
+
+    @Override
+    public LikeModel save(LikeModel likeModel) {
+        return likeJpaRepository.save(likeModel);
+    }
+
+    @Override
+    public void delete(LikeModel likeModel) {
+        likeJpaRepository.delete(likeModel);
+    }
+
+    @Override
+    public long getProductLikeCount(Long productId) {
+        Long likeCount = queryFactory.select(likeModel.count())
+            .from(likeModel)
+            .where(likeModel.productId.eq(productId))
+            .fetchOne();
+        return likeCount != null ? likeCount : 0L;
+    }
+
+    @Override
+    public List<LikeModel> search(MemberModel member, Pageable pageable) {
+        return queryFactory.selectFrom(likeModel)
+            .where(likeModel.memberId.eq(member.getId()))
+            .orderBy(likeModel.createdAt.desc())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+    }
+
+    @Override
+    public long countMemberLikedProducts(Long memberId) {
+        Long count = queryFactory.select(likeModel.count())
+            .from(likeModel)
+            .where(likeModel.memberId.eq(memberId))
+            .fetchOne();
+        return count != null ? count : 0L;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/orders/DeliveryClient.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/orders/DeliveryClient.java
@@ -1,0 +1,15 @@
+package com.loopers.infrastructure.orders;
+
+import com.loopers.domain.orders.ExternalServiceOutputPort;
+import com.loopers.domain.orders.OrdersModel;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DeliveryClient implements ExternalServiceOutputPort {
+
+    @Override
+    public void send(OrdersModel order) {
+
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/orders/OrderItemJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/orders/OrderItemJpaRepository.java
@@ -1,0 +1,8 @@
+package com.loopers.infrastructure.orders;
+
+import com.loopers.domain.orders.OrderItemModel;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderItemJpaRepository extends JpaRepository<OrderItemModel, Long> {
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/orders/OrderJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/orders/OrderJpaRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.infrastructure.orders;
+
+import com.loopers.domain.orders.OrdersModel;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderJpaRepository extends JpaRepository<OrdersModel, Long> {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/orders/OrderRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/orders/OrderRepositoryImpl.java
@@ -1,0 +1,54 @@
+package com.loopers.infrastructure.orders;
+
+import com.loopers.domain.orders.OrderItemModel;
+import com.loopers.domain.orders.OrderRepository;
+import com.loopers.domain.orders.OrdersModel;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.loopers.domain.orders.QOrderItemModel.orderItemModel;
+import static com.loopers.domain.orders.QOrdersModel.ordersModel;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderRepositoryImpl implements OrderRepository {
+
+    private final OrderJpaRepository orderJpaRepository;
+    private final OrderItemJpaRepository orderItemJpaRepository;
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public OrdersModel save(OrdersModel order) {
+        return orderJpaRepository.save(order);
+    }
+
+    @Override
+    public List<OrderItemModel> saveAll(Set<OrderItemModel> items) {
+        return orderItemJpaRepository.saveAll(items);
+    }
+
+    @Override
+    public List<OrdersModel> search(Long memberId) {
+        return queryFactory
+            .selectFrom(ordersModel)
+            .distinct()
+            .leftJoin(ordersModel.items, orderItemModel).fetchJoin()
+            .where(ordersModel.memberId.eq(memberId))
+            .fetch();
+    }
+
+    @Override
+    public Optional<OrdersModel> find(Long orderId) {
+        OrdersModel order = queryFactory
+            .selectFrom(ordersModel)
+            .leftJoin(ordersModel.items, orderItemModel).fetchJoin()
+            .where(ordersModel.id.eq(orderId))
+            .fetchOne();
+        return Optional.ofNullable(order);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.infrastructure.product;
+
+import com.loopers.domain.product.ProductModel;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductJpaRepository extends JpaRepository<ProductModel, Long> {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
@@ -1,0 +1,107 @@
+package com.loopers.infrastructure.product;
+
+import com.loopers.domain.product.ProductModel;
+import com.loopers.domain.product.ProductRepository;
+import com.loopers.domain.product.enums.OrderBy;
+import com.loopers.domain.product.spec.BrandEqualSpecification;
+import com.loopers.domain.product.spec.ProductSearchCondition;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.util.Pair;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.loopers.domain.product.QProductModel.productModel;
+
+@Repository
+@RequiredArgsConstructor
+public class ProductRepositoryImpl implements ProductRepository {
+
+    private final ProductJpaRepository productJpaRepository;
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<ProductModel> search(ProductSearchCondition condition, Pageable pageable) {
+        if (condition == null || pageable == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "Search condition or pageable cannot be null");
+        }
+
+        BooleanBuilder predicates = new BooleanBuilder();
+        predicates.and(BrandEqualSpecification.of(condition.getBrand()).isSatisfiedBy(productModel));
+
+        List<Pair<String, Direction>> sorts = pageable.getSort().stream().map(order -> Pair.of(order.getProperty(), order.getDirection())).toList();
+        return queryFactory.selectFrom(productModel)
+            .where(predicates)
+            .orderBy(sorts.stream().map(this::toOrderBy).toArray(OrderSpecifier<?>[]::new))
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+    }
+
+    @Override
+    public long getTotalAmount(ProductSearchCondition condition) {
+        if (condition == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "Search condition cannot be null");
+        }
+
+        BooleanBuilder predicates = new BooleanBuilder();
+        predicates.and(BrandEqualSpecification.of(condition.getBrand()).isSatisfiedBy(productModel));
+
+        Long totalCount = queryFactory.select(productModel.count())
+            .from(productModel)
+            .where(predicates)
+            .fetchOne();
+        return totalCount != null ? totalCount : 0L;
+    }
+
+    @Override
+    public List<ProductModel> findAll(Set<Long> productIds) {
+        if (productIds == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "Product IDs cannot be null");
+        }
+
+        if (productIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return queryFactory.selectFrom(productModel)
+            .where(productModel.id.in(productIds))
+            .fetch();
+    }
+
+    @Override
+    public Optional<ProductModel> find(Long productId) {
+        if (productId == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "Product ID cannot be null");
+        }
+
+        return Optional.ofNullable(queryFactory.selectFrom(productModel)
+            .where(productModel.id.eq(productId))
+            .fetchOne());
+    }
+
+    @Override
+    public ProductModel save(ProductModel product) {
+        return productJpaRepository.save(product);
+    }
+
+    private OrderSpecifier<?> toOrderBy(Pair<String, Direction> sort) {
+        final String property = sort.getFirst();
+        final Direction direction = sort.getSecond();
+        return switch (OrderBy.fromValue(property)) {
+            case LATEST -> direction.isAscending() ? productModel.createdAt.asc() : productModel.createdAt.desc();
+            case LIKES -> direction.isAscending() ? productModel.likeCount.asc() : productModel.likeCount.desc();
+            case PRICE -> direction.isAscending() ? productModel.price.amount.asc() : productModel.price.amount.desc();
+        };
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/support/Specification.java
+++ b/apps/commerce-api/src/main/java/com/loopers/support/Specification.java
@@ -1,0 +1,7 @@
+package com.loopers.support;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+
+public interface Specification<T> {
+    BooleanExpression isSatisfiedBy(T candidate);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/support/error/ErrorType.java
+++ b/apps/commerce-api/src/main/java/com/loopers/support/error/ErrorType.java
@@ -7,11 +7,14 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum ErrorType {
-    /** 범용 에러 */
+    /**
+     * 범용 에러
+     */
     INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase(), "일시적인 오류가 발생했습니다."),
     BAD_REQUEST(HttpStatus.BAD_REQUEST, HttpStatus.BAD_REQUEST.getReasonPhrase(), "잘못된 요청입니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, HttpStatus.NOT_FOUND.getReasonPhrase(), "존재하지 않는 요청입니다."),
-    CONFLICT(HttpStatus.CONFLICT, HttpStatus.CONFLICT.getReasonPhrase(), "이미 존재하는 리소스입니다.");
+    CONFLICT(HttpStatus.CONFLICT, HttpStatus.CONFLICT.getReasonPhrase(), "이미 존재하는 리소스입니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, HttpStatus.FORBIDDEN.getReasonPhrase(), "리소스 접근 권한이 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/apps/commerce-api/src/test/java/com/loopers/domain/brand/BrandModelTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/brand/BrandModelTest.java
@@ -1,0 +1,43 @@
+package com.loopers.domain.brand;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class BrandModelTest {
+
+    @DisplayName("브랜드 모델을 생성할 때, ")
+    @Nested
+    class Create {
+        @DisplayName("이름이 빈칸 혹은 null 이면, BAD_REQUEST 예외가 발생한다")
+        @ParameterizedTest
+        @NullAndEmptySource
+        void throwsBadRequestException_whenNameIsNullOrBlank(String name) {
+            CoreException result = assertThrows(CoreException.class, () -> {
+                new BrandModel(name, "Test Description");
+            });
+
+            assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+
+        @DisplayName("설명이 빈칸이면, BAD_REQUEST 예외가 발생한다")
+        @ParameterizedTest
+        @ValueSource(strings = {"", "   "})
+        void throwsBadRequestException_whenDescriptionIsBlank(String description) {
+            String name = "Test Brand";
+
+            CoreException result = assertThrows(CoreException.class, () -> {
+                BrandModel brandModel = new BrandModel(name, description);
+            });
+
+            assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/brand/BrandServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/brand/BrandServiceTest.java
@@ -1,0 +1,100 @@
+package com.loopers.domain.brand;
+
+import com.loopers.domain.product.ProductModel;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BrandServiceTest {
+
+    @Mock
+    private BrandRepository brandRepository;
+
+    @InjectMocks
+    private BrandService brandService;
+
+    @Test
+    void getDetail_정상조회() {
+        BrandModel brand = mock(BrandModel.class);
+        when(brandRepository.find(1L)).thenReturn(Optional.of(brand));
+
+        BrandModel result = brandService.getDetail(1L);
+
+        assertEquals(brand, result);
+    }
+
+    @Test
+    void getDetail_존재하지않으면_예외() {
+        when(brandRepository.find(2L)).thenReturn(Optional.empty());
+
+        CoreException ex = assertThrows(CoreException.class, () -> brandService.getDetail(2L));
+        assertEquals(ErrorType.NOT_FOUND, ex.getErrorType());
+    }
+
+    @Test
+    void getDetail_null이면_예외() {
+        CoreException ex = assertThrows(CoreException.class, () -> brandService.getDetail(null));
+        assertEquals(ErrorType.BAD_REQUEST, ex.getErrorType());
+    }
+
+    @Test
+    void getBrands_정상조회() {
+        Set<Long> ids = Set.of(1L, 2L);
+        List<BrandModel> brands = List.of(mock(BrandModel.class), mock(BrandModel.class));
+        when(brandRepository.findAll(ids)).thenReturn(brands);
+
+        List<BrandModel> result = brandService.getBrands(ids);
+
+        assertEquals(brands, result);
+    }
+
+    @Test
+    void getBrands_null이면_예외() {
+        CoreException ex = assertThrows(CoreException.class, () -> brandService.getBrands(null));
+        assertEquals(ErrorType.BAD_REQUEST, ex.getErrorType());
+    }
+
+    @Test
+    void getBrands_빈셋이면_빈리스트() {
+        List<BrandModel> result = brandService.getBrands(Collections.emptySet());
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void getRepresentativeProducts_정상동작() {
+        BrandModel brand = mock(BrandModel.class);
+        when(brand.getId()).thenReturn(1L);
+
+        ProductModel p1 = mock(ProductModel.class);
+        ProductModel p2 = mock(ProductModel.class);
+        ProductModel p3 = mock(ProductModel.class);
+
+        when(p1.getBrandId()).thenReturn(1L);
+        when(p2.getBrandId()).thenReturn(1L);
+        when(p3.getBrandId()).thenReturn(2L);
+
+        when(p1.getLikeCount()).thenReturn(5L);
+        when(p2.getLikeCount()).thenReturn(10L);
+
+        List<ProductModel> products = List.of(p1, p2, p3);
+
+        List<ProductModel> result = brandService.getRepresentativeProducts(brand, products, 1);
+
+        assertEquals(1, result.size());
+        assertEquals(p2, result.get(0)); // likeCount 높은 순
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeModelTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeModelTest.java
@@ -1,0 +1,41 @@
+package com.loopers.domain.like;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class LikeModelTest {
+
+    @DisplayName("좋아요 모델을 생성할 때, ")
+    @Nested
+    class Create {
+        @DisplayName("회원 아이디 혹은 상품 아이디가 null 이면, BAD_REQUEST 예외가 발생한다")
+        @Test
+        void throwsBadRequestException_whenMemberIdOrProductIdIsNull() {
+            Long memberId = 1L;
+            Long productId = 1L;
+
+            assertAll(
+                    () -> {
+                        CoreException exception = assertThrows(CoreException.class, () -> new LikeModel(null, productId));
+                        assertEquals(ErrorType.BAD_REQUEST, exception.getErrorType());
+                    },
+                    () -> {
+                        CoreException exception = assertThrows(CoreException.class, () -> new LikeModel(memberId, null));
+                        assertEquals(ErrorType.BAD_REQUEST, exception.getErrorType());
+                    },
+                    () -> {
+                        CoreException exception = assertThrows(CoreException.class, () -> new LikeModel(null, null));
+                        assertEquals(ErrorType.BAD_REQUEST, exception.getErrorType());
+                    }
+            );
+        }
+    }
+
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeServiceTest.java
@@ -1,0 +1,140 @@
+package com.loopers.domain.like;
+
+import com.loopers.domain.member.MemberModel;
+import com.loopers.domain.product.ProductModel;
+import com.loopers.support.error.CoreException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class LikeServiceTest {
+
+    @Mock
+    private LikeRepository likeRepository;
+
+    @InjectMocks
+    private LikeService likeService;
+
+    @Test
+    void like_정상동작() {
+        MemberModel member = mock(MemberModel.class);
+        ProductModel product = mock(ProductModel.class);
+        when(member.getId()).thenReturn(1L);
+        when(product.getId()).thenReturn(2L);
+        when(likeRepository.find(1L, 2L)).thenReturn(Optional.empty());
+
+        likeService.like(member, product);
+
+        verify(likeRepository).save(any(LikeModel.class));
+    }
+
+    @Test
+    void like_이미_좋아요_있으면_save_호출안함() {
+        MemberModel member = mock(MemberModel.class);
+        ProductModel product = mock(ProductModel.class);
+        when(member.getId()).thenReturn(1L);
+        when(product.getId()).thenReturn(2L);
+        when(likeRepository.find(1L, 2L)).thenReturn(Optional.of(mock(LikeModel.class)));
+
+        likeService.like(member, product);
+
+        verify(likeRepository, never()).save(any());
+    }
+
+    @Test
+    void like_null_입력시_예외() {
+        assertThrows(CoreException.class, () -> likeService.like(null, null));
+    }
+
+    @Test
+    void unlike_정상동작() {
+        MemberModel member = mock(MemberModel.class);
+        ProductModel product = mock(ProductModel.class);
+        LikeModel like = mock(LikeModel.class);
+        when(member.getId()).thenReturn(1L);
+        when(product.getId()).thenReturn(2L);
+        when(likeRepository.find(1L, 2L)).thenReturn(Optional.of(like));
+
+        likeService.unlike(member, product);
+
+        verify(likeRepository).delete(like);
+    }
+
+    @Test
+    void unlike_좋아요없으면_delete_호출안함() {
+        MemberModel member = mock(MemberModel.class);
+        ProductModel product = mock(ProductModel.class);
+        when(member.getId()).thenReturn(1L);
+        when(product.getId()).thenReturn(2L);
+        when(likeRepository.find(1L, 2L)).thenReturn(Optional.empty());
+
+        likeService.unlike(member, product);
+
+        verify(likeRepository, never()).delete(any());
+    }
+
+    @Test
+    void unlike_null_입력시_예외() {
+        assertThrows(CoreException.class, () -> likeService.unlike(null, null));
+    }
+
+    @Test
+    void getLikeCount_정상동작() {
+        ProductModel product = mock(ProductModel.class);
+        when(product.getId()).thenReturn(2L);
+        when(likeRepository.getProductLikeCount(2L)).thenReturn(5L);
+
+        long count = likeService.getLikeCount(product);
+
+        assertEquals(5L, count);
+    }
+
+    @Test
+    void getLikeCount_null_입력시_예외() {
+        assertThrows(CoreException.class, () -> likeService.getLikeCount(null));
+    }
+
+    @Test
+    void getLikes_정상동작() {
+        MemberModel member = mock(MemberModel.class);
+        Pageable pageable = mock(Pageable.class);
+        List<LikeModel> likes = List.of(mock(LikeModel.class));
+        when(likeRepository.search(member, pageable)).thenReturn(likes);
+
+        List<LikeModel> result = likeService.getLikes(member, pageable);
+
+        assertEquals(likes, result);
+    }
+
+    @Test
+    void getLikes_null_입력시_예외() {
+        assertThrows(CoreException.class, () -> likeService.getLikes(null, null));
+    }
+
+    @Test
+    void countLikedProducts_정상동작() {
+        MemberModel member = mock(MemberModel.class);
+        when(member.getId()).thenReturn(1L);
+        when(likeRepository.countMemberLikedProducts(1L)).thenReturn(3L);
+
+        long count = likeService.countLikedProducts(member);
+
+        assertEquals(3L, count);
+    }
+
+    @Test
+    void countLikedProducts_null_입력시_예외() {
+        assertThrows(CoreException.class, () -> likeService.countLikedProducts(null));
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/member/MemberModelTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/member/MemberModelTest.java
@@ -31,14 +31,14 @@ class MemberModelTest {
             MemberModel memberModel = new MemberModel(userId, gender, birthdate, email);
 
             assertAll(
-                    () -> assertThat(memberModel.getId()).isNotNull(),
-                    () -> assertThat(memberModel.getUserId()).isEqualTo(userId),
-                    () -> assertThat(memberModel.getGender()).isEqualTo(gender),
-                    () -> assertThat(memberModel.getBirthdate()).isEqualTo(
-                            LocalDate.of(2020, 1, 1)
-                    ),
-                    () -> assertThat(memberModel.getEmail()).isEqualTo(email),
-                    () -> assertThat(memberModel.getPoints()).isEqualTo(0L)
+                () -> assertThat(memberModel.getId()).isNotNull(),
+                () -> assertThat(memberModel.getUserId()).isEqualTo(userId),
+                () -> assertThat(memberModel.getGender()).isEqualTo(gender),
+                () -> assertThat(memberModel.getBirthdate()).isEqualTo(
+                    LocalDate.of(2020, 1, 1)
+                ),
+                () -> assertThat(memberModel.getEmail()).isEqualTo(email),
+                () -> assertThat(memberModel.getPoints()).isEqualTo(0L)
             );
         }
 
@@ -106,8 +106,44 @@ class MemberModelTest {
             CoreException result = assertThrows(CoreException.class, () -> {
                 member.chargePoints(points);
             });
-            
+
             assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+    }
+
+    @DisplayName("포인트 사용 시")
+    @Nested
+    class UsePoints {
+
+        @DisplayName("정상적으로 포인트를 사용할 수 있다.")
+        @Test
+        void usePoints_success() {
+            MemberModel member = new MemberModel("test", Gender.MALE, "2020-01-01", "test@test.com", 100L);
+
+            member.usePoints(30L);
+
+            assertThat(member.getPoints()).isEqualTo(70L);
+        }
+
+        @DisplayName("0 이하의 금액을 사용하면 BAD_REQUEST 예외가 발생한다.")
+        @Test
+        void usePoints_zeroOrNegative_throwsException() {
+            MemberModel member = new MemberModel("test", Gender.MALE, "2020-01-01", "test@test.com", 100L);
+
+            CoreException ex1 = assertThrows(CoreException.class, () -> member.usePoints(0L));
+            assertThat(ex1.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+
+            CoreException ex2 = assertThrows(CoreException.class, () -> member.usePoints(-10L));
+            assertThat(ex2.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+
+        @DisplayName("잔액보다 많은 금액을 사용하면 CONFLICT 예외가 발생한다.")
+        @Test
+        void usePoints_insufficientPoints_throwsException() {
+            MemberModel member = new MemberModel("test", Gender.MALE, "2020-01-01", "test@test.com", 50L);
+
+            CoreException ex = assertThrows(CoreException.class, () -> member.usePoints(100L));
+            assertThat(ex.getErrorType()).isEqualTo(ErrorType.CONFLICT);
         }
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/orders/OrderItemModelTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/orders/OrderItemModelTest.java
@@ -1,0 +1,58 @@
+package com.loopers.domain.orders;
+
+import com.loopers.domain.orders.vo.Price;
+import com.loopers.domain.orders.vo.ProductSnapshot;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class OrderItemModelTest {
+
+    @DisplayName("주문 아이템을 생성할 때, ")
+    @Nested
+    class Create {
+        @DisplayName("주문이 null이면 예외가 발생한다.")
+        @Test
+        void throwsException_whenOrdersIsNull() {
+            // given
+            OrdersModel orders = null;
+            ProductSnapshot productSnapshot = ProductSnapshot.of(1L, "productName", Price.ZERO);
+            Long quantity = 1L;
+
+            // when & then
+            CoreException exception = assertThrows(CoreException.class, () -> new OrderItemModel(orders, productSnapshot, quantity));
+            assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+
+        @DisplayName("상품 스냅샷이 null이면 예외가 발생한다.")
+        @Test
+        void throwsException_whenProductSnapshotIsNull() {
+            // given
+            OrdersModel orders = new OrdersModel(1L, Price.ZERO);
+            ProductSnapshot productSnapshot = null;
+            Long quantity = 1L;
+
+            // when & then
+            CoreException exception = assertThrows(CoreException.class, () -> new OrderItemModel(orders, productSnapshot, quantity));
+            assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+
+        @DisplayName("수량이 null이면 예외가 발생한다.")
+        @Test
+        void throwsException_whenQuantityIsNull() {
+            // given
+            OrdersModel orders = new OrdersModel(1L, Price.ZERO);
+            ProductSnapshot productSnapshot = ProductSnapshot.of(1L, "productName", Price.ZERO);
+            Long quantity = null;
+
+            // when & then
+            CoreException exception = assertThrows(CoreException.class, () -> new OrderItemModel(orders, productSnapshot, quantity));
+            assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/orders/OrderServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/orders/OrderServiceTest.java
@@ -1,0 +1,153 @@
+package com.loopers.domain.orders;
+
+import com.loopers.domain.member.MemberModel;
+import com.loopers.domain.member.enums.Gender;
+import com.loopers.domain.orders.vo.Price;
+import com.loopers.domain.product.ProductModel;
+import com.loopers.domain.product.vo.Stock;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.util.Pair;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OrderServiceTest {
+
+    @Mock
+    OrderRepository orderRepository;
+
+    @InjectMocks
+    OrderService orderService;
+
+    @Nested
+    @DisplayName("order 메서드")
+    class Order {
+
+        @Test
+        @DisplayName("정상 주문 시 주문과 아이템 저장이 호출된다")
+        void order_success() {
+            MemberModel member = new MemberModel("user1", Gender.FEMALE, "2000-01-01", "test@test.com", 1000L);
+            ProductModel product = mock(ProductModel.class);
+            when(product.getId()).thenReturn(10L);
+            when(product.getName()).thenReturn("상품");
+            when(product.getPrice()).thenReturn(com.loopers.domain.product.vo.Price.of(new BigDecimal("1000")));
+
+            List<Pair<ProductModel, Long>> products = List.of(Pair.of(product, 2L));
+            OrdersModel order = new OrdersModel(member.getId(), Price.of(new BigDecimal("2000")));
+
+            when(orderRepository.save(any(OrdersModel.class))).thenReturn(order);
+
+            OrdersModel result = orderService.order(member, products);
+
+            assertThat(result).isNotNull();
+            verify(orderRepository).save(any(OrdersModel.class));
+            verify(orderRepository).saveAll(any());
+        }
+
+        @Test
+        @DisplayName("member가 null이면 BAD_REQUEST 예외 발생")
+        void order_memberNull_throwsException() {
+            List<Pair<ProductModel, Long>> products = List.of();
+            CoreException ex = assertThrows(CoreException.class, () -> orderService.order(null, products));
+            assertThat(ex.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+
+        @Test
+        @DisplayName("products가 null이면 BAD_REQUEST 예외 발생")
+        void order_productsNull_throwsException() {
+            MemberModel member = new MemberModel("user1", Gender.FEMALE, "2000-01-01", "test@test.com", 1000L);
+            CoreException ex = assertThrows(CoreException.class, () -> orderService.order(member, null));
+            assertThat(ex.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+
+        @Test
+        @DisplayName("products가 비어있으면 BAD_REQUEST 예외 발생")
+        void order_productsEmpty_throwsException() {
+            MemberModel member = new MemberModel("user1", Gender.FEMALE, "2000-01-01", "test@test.com", 1000L);
+            CoreException ex = assertThrows(CoreException.class, () -> orderService.order(member, Collections.emptyList()));
+            assertThat(ex.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+
+        @Test
+        @DisplayName("quantity가 0 이하이면 BAD_REQUEST 예외 발생")
+        void order_quantityZeroOrNegative_throwsException() {
+            MemberModel member = new MemberModel("user1", Gender.FEMALE, "2000-01-01", "test@test.com", 1000L);
+            ReflectionTestUtils.setField(member, "id", 123L);
+            ProductModel product = new ProductModel("p1", com.loopers.domain.product.vo.Price.ZERO, Stock.of(1568), 369L);
+            ReflectionTestUtils.setField(product, "id", 123L);
+            List<Pair<ProductModel, Long>> products = List.of(Pair.of(product, 0L));
+            CoreException ex = assertThrows(CoreException.class, () -> orderService.order(member, products));
+            assertThat(ex.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+    }
+
+    @Nested
+    @DisplayName("getOrders 메서드")
+    class GetOrders {
+        @Test
+        @DisplayName("정상적으로 주문 목록을 조회한다")
+        void getOrders_success() {
+            MemberModel member = new MemberModel("user1", Gender.FEMALE, "2000-01-01", "test@test.com", 1000L);
+            List<OrdersModel> orders = List.of(mock(OrdersModel.class));
+            when(orderRepository.search(member.getId())).thenReturn(orders);
+
+            List<OrdersModel> result = orderService.getOrders(member);
+
+            assertThat(result).isEqualTo(orders);
+        }
+
+        @Test
+        @DisplayName("member가 null이면 BAD_REQUEST 예외 발생")
+        void getOrders_memberNull_throwsException() {
+            CoreException ex = assertThrows(CoreException.class, () -> orderService.getOrders(null));
+            assertThat(ex.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+    }
+
+    @Nested
+    @DisplayName("getDetail 메서드")
+    class GetDetail {
+        @Test
+        @DisplayName("정상적으로 주문 상세를 조회한다")
+        void getDetail_success() {
+            OrdersModel order = mock(OrdersModel.class);
+            when(orderRepository.find(1L)).thenReturn(Optional.of(order));
+
+            OrdersModel result = orderService.getDetail(1L);
+
+            assertThat(result).isEqualTo(order);
+        }
+
+        @Test
+        @DisplayName("orderId가 null이면 BAD_REQUEST 예외 발생")
+        void getDetail_orderIdNull_throwsException() {
+            CoreException ex = assertThrows(CoreException.class, () -> orderService.getDetail(null));
+            assertThat(ex.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 주문이면 NOT_FOUND 예외 발생")
+        void getDetail_notFound_throwsException() {
+            when(orderRepository.find(1L)).thenReturn(Optional.empty());
+            CoreException ex = assertThrows(CoreException.class, () -> orderService.getDetail(1L));
+            assertThat(ex.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/orders/OrdersModelTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/orders/OrdersModelTest.java
@@ -1,0 +1,100 @@
+package com.loopers.domain.orders;
+
+import com.loopers.domain.orders.enums.OrderStatus;
+import com.loopers.domain.orders.vo.Price;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class OrdersModelTest {
+
+    @Mock
+    OrderItemModel mockItem;
+
+    @DisplayName("주문 모델을 생성할 때, ")
+    @Nested
+    class Create {
+
+        @DisplayName("회원 아이디가 null 이면, 예외가 발생한다.")
+        @Test
+        void throwsException_whenMemberIdIsNull() {
+            // Given
+            Long memberId = null;
+            Price totalPrice = Price.of(new BigDecimal("10000"));
+
+            // When & Then
+            CoreException result = assertThrows(CoreException.class, () -> {
+                new OrdersModel(memberId, totalPrice);
+            });
+
+            assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+
+        @DisplayName("총 가격이 null 이면, 예외가 발생한다.")
+        @Test
+        void throwsException_whenTotalPriceIsNull() {
+            // Given
+            Long memberId = 1L;
+            Price totalPrice = null;
+
+            // When & Then
+            CoreException result = assertThrows(CoreException.class, () -> {
+                new OrdersModel(memberId, totalPrice);
+            });
+
+            assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+
+        @DisplayName("인자가 모두 주어지면, 정상적으로 생성된다.")
+        @Test
+        void orderModelCreated_whenAllArgumentsAreProvided() {
+            // Given
+            Long memberId = 1L;
+            Price totalPrice = Price.of(new BigDecimal("10000"));
+
+            // When
+            OrdersModel ordersModel = new OrdersModel(memberId, totalPrice);
+
+            // Then
+            assertAll(
+                    () -> assertThat(ordersModel.getMemberId()).isEqualTo(memberId),
+                    () -> assertThat(ordersModel.getTotalPrice()).isEqualTo(totalPrice),
+                    () -> assertThat(ordersModel.getStatus()).isEqualTo(OrderStatus.NOT_PAID)
+            );
+        }
+    }
+
+    @DisplayName("주문 모델에 아이템을 추가할 때, ")
+    @Nested
+    class AddItem {
+
+        @DisplayName("addItem 호출 시 아이템이 주문에 추가되고, 아이템의 orders 필드가 해당 주문을 참조한다.")
+        @Test
+        void setsOrderReferenceAndAddsToItems_whenAddItemIsCalled() {
+            // Given
+            Long memberId = 1L;
+            Price totalPrice = Price.of(new BigDecimal("10000"));
+            OrdersModel ordersModel = new OrdersModel(memberId, totalPrice);
+
+            // When
+            ordersModel.addItem(mockItem);
+
+            // Then
+            assertThat(ordersModel.getItems()).contains(mockItem);
+            verify(mockItem).setOrders(ordersModel);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/orders/vo/PriceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/orders/vo/PriceTest.java
@@ -1,0 +1,97 @@
+package com.loopers.domain.orders.vo;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class PriceTest {
+    @DisplayName("가격을 생성할 때, ")
+    @Nested
+    class Create {
+        @DisplayName("null 이나 음수가 주어진 경우, 예외가 발생한다.")
+        @Test
+        void throwsException_whenAmountIsNullOrNegative() {
+            assertAll(
+                    () -> {
+                        CoreException result = assertThrows(
+                                CoreException.class,
+                                () -> Price.of(null)
+                        );
+                        assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+                    },
+                    () -> {
+                        CoreException result = assertThrows(
+                                CoreException.class,
+                                () -> Price.of(new BigDecimal("-1"))
+                        );
+                        assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+                    }
+            );
+        }
+    }
+
+    @DisplayName("가격을 더할 때, ")
+    @Nested
+    class Add {
+        @DisplayName("null 이 주어진 경우, 예외가 발생한다.")
+        @Test
+        void throwsException_whenAddingNullOrNegativePrice() {
+            Price price = Price.of(new BigDecimal("100"));
+
+            CoreException result = assertThrows(
+                    CoreException.class,
+                    () -> price.add(null)
+            );
+            assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+
+        @DisplayName("올바른 값이 주어지면, 정상적으로 가격을 더할 수 있다.")
+        @Test
+        void canAddPrices() {
+            Price price1 = Price.of(new BigDecimal("100"));
+            Price price2 = Price.of(new BigDecimal("50"));
+            Price result = price1.add(price2);
+
+            assertThat(result).isEqualTo(Price.of(new BigDecimal("150")));
+        }
+    }
+
+    @DisplayName("가격 비교를 할 때, ")
+    @Nested
+    class EqualsAndHashCode {
+        @DisplayName("같은 가격이면, 동일하게 취급된다.")
+        @Test
+        void equalsReturnsTrue_whenPriceIsEqual() {
+            Price price1 = Price.of(new BigDecimal("100"));
+            Price price2 = Price.of(new BigDecimal("100"));
+
+            assertThat(price1).isEqualTo(price2);
+        }
+
+        @DisplayName("다른 가격이면, equals 가 false 를 반환한다.")
+        @Test
+        void equalsReturnsFalse_whenPricesAreNotEqual() {
+            Price price1 = Price.of(new BigDecimal("100"));
+            Price price2 = Price.of(new BigDecimal("50"));
+
+            assertThat(price1).isNotEqualTo(price2);
+        }
+
+        @DisplayName("동일한 가격의 해시코드는 동일하다.")
+        @Test
+        void hashCodeIsSame_whenPricesAreEqual() {
+            Price price1 = Price.of(new BigDecimal("100"));
+            Price price2 = Price.of(new BigDecimal("100"));
+
+            assertThat(price1.hashCode()).isEqualTo(price2.hashCode());
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/orders/vo/ProductSnapshotTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/orders/vo/ProductSnapshotTest.java
@@ -1,0 +1,64 @@
+package com.loopers.domain.orders.vo;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ProductSnapshotTest {
+
+    @DisplayName("상품 스냅샷을 생성할 때, ")
+    @Nested
+    class Create {
+        @DisplayName("상품 ID가 null 이 주어지면, 예외를 던진다.")
+        @Test
+        void throwsException_whenProductIdIsNull() {
+            Long productId = null;
+            String name = "Test Product";
+            Price price = Price.of(new BigDecimal("1000"));
+
+            CoreException exception = assertThrows(CoreException.class, () -> {
+                ProductSnapshot.of(productId, name, price);
+            });
+
+            assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+
+        @DisplayName("상품 이름이 null 혹은 빈 값 이 주어지면, 예외를 던진다.")
+        @ParameterizedTest
+        @NullAndEmptySource
+        void throwsException_whenNameIsNull(String name) {
+            Long productId = 1L;
+            Price price = Price.of(new BigDecimal("1000"));
+
+            CoreException exception = assertThrows(CoreException.class, () -> {
+                ProductSnapshot.of(productId, name, price);
+            });
+
+            assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+
+        @DisplayName("가격이 null 이 주어지면, 예외를 던진다.")
+        @Test
+        void throwsException_whenPriceIsNull() {
+            Long productId = 1L;
+            String name = "Test Product";
+            Price price = null;
+
+            CoreException exception = assertThrows(CoreException.class, () -> {
+                ProductSnapshot.of(productId, name, price);
+            });
+
+            assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+    }
+
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductModelTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductModelTest.java
@@ -1,0 +1,145 @@
+package com.loopers.domain.product;
+
+import com.loopers.domain.product.vo.Price;
+import com.loopers.domain.product.vo.Stock;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ProductModelTest {
+
+    @Mock
+    Stock mockStock;
+
+    @DisplayName("상품 모델을 생성할 때, ")
+    @Nested
+    class Create {
+
+        @DisplayName("이름이 null 이거나 빈칸이면, BAD_REQUEST 예외가 발생한다")
+        @ParameterizedTest
+        @NullAndEmptySource
+        void throwsBadRequestException_whenNameIsNullOrBlank(String name) {
+            // When & Then
+            CoreException result = assertThrows(
+                CoreException.class,
+                () -> new ProductModel(name, Price.ZERO, Stock.ZERO, 1L)
+            );
+            assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+
+        @DisplayName("가격이 null 이면, BAD_REQUEST 예외가 발생한다")
+        @Test
+        void throwsBadRequestException_whenPriceIsNull() {
+            // When & Then
+            CoreException result = assertThrows(
+                CoreException.class,
+                () -> new ProductModel("product name", null, Stock.ZERO, 1L)
+            );
+            assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+
+        @DisplayName("재고가 null 이면, BAD_REQUEST 예외가 발생한다")
+        @Test
+        void throwsBadRequestException_whenStockIsNull() {
+            // When & Then
+            CoreException result = assertThrows(
+                CoreException.class,
+                () -> new ProductModel("product name", Price.ZERO, null, 1L)
+            );
+            assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+
+        @DisplayName("브랜드 아이디가 null 이면, BAD_REQUEST 예외가 발생한다")
+        @Test
+        void throwsBadRequestException_whenBrandIdIsNull() {
+            // When & Then
+            CoreException result = assertThrows(
+                CoreException.class,
+                () -> new ProductModel("product name", Price.ZERO, Stock.ZERO, null)
+            );
+            assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+
+        @DisplayName("모든 필드가 유효하면, 정상적으로 생성된다.")
+        @Test
+        void createProductModel_whenAllFieldsAreValid() {
+            // Given
+            String name = "Test Product";
+            Price price = Price.of(BigDecimal.valueOf(1000));
+            Stock stock = Stock.of(10L);
+            Long brandId = 1L;
+
+            // When
+            ProductModel productModel = new ProductModel(name, price, stock, brandId);
+
+            // Then
+            assertThat(productModel.getName()).isEqualTo(name);
+            assertThat(productModel.getPrice()).isEqualTo(price);
+            assertThat(productModel.getStock()).isEqualTo(stock);
+            assertThat(productModel.getBrandId()).isEqualTo(brandId);
+            assertThat(productModel.getLikeCount()).isEqualTo(0);
+        }
+    }
+
+    @DisplayName("상품 모델의 재고를 감소시킬 때, ")
+    @Nested
+    class DecreaseStock {
+
+        @DisplayName("상품 모델의 재고 감소 시, Stock.deduct()가 호출된다")
+        @Test
+        void decreaseStock_callsDeductMethodOfStock() {
+            // Given
+            when(mockStock.deduct(5L)).thenReturn(mockStock);
+            ProductModel productModel = new ProductModel("상품명", Price.ZERO, mockStock, 1L);
+
+            // When
+            productModel.decreaseStock(5L);
+
+            // Then
+            verify(mockStock).deduct(5L);
+            assertThat(productModel.getStock()).isEqualTo(mockStock);
+        }
+    }
+
+    @DisplayName("좋아요 수를 업데이트할 때, ")
+    @Nested
+    class UpdateLikeCount {
+
+        @DisplayName("0 이상의 값이면 정상적으로 업데이트된다")
+        @Test
+        void updateLikeCount_success() {
+            ProductModel product = new ProductModel("상품", Price.ZERO, Stock.ZERO, 1L);
+
+            product.updateLikeCount(10L);
+
+            assertThat(product.getLikeCount()).isEqualTo(10L);
+
+            product.updateLikeCount(0L);
+            assertThat(product.getLikeCount()).isEqualTo(0L);
+        }
+
+        @DisplayName("음수로 업데이트하면 BAD_REQUEST 예외가 발생한다")
+        @Test
+        void updateLikeCount_negative_throwsException() {
+            ProductModel product = new ProductModel("상품", Price.ZERO, Stock.ZERO, 1L);
+
+            CoreException ex = assertThrows(CoreException.class, () -> product.updateLikeCount(-1L));
+            assertThat(ex.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceTest.java
@@ -1,0 +1,198 @@
+package com.loopers.domain.product;
+
+import com.loopers.domain.product.spec.ProductSearchCondition;
+import com.loopers.domain.product.vo.Stock;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ProductServiceTest {
+
+    @Mock
+    ProductRepository productRepository;
+
+    @InjectMocks
+    ProductService productService;
+
+    @Nested
+    @DisplayName("search")
+    class Search {
+        @Test
+        void 정상_조회() {
+            ProductSearchCondition condition = mock(ProductSearchCondition.class);
+            Pageable pageable = PageRequest.of(0, 10);
+            List<ProductModel> products = List.of(mock(ProductModel.class));
+            when(productRepository.search(condition, pageable)).thenReturn(products);
+
+            List<ProductModel> result = productService.search(condition, pageable);
+
+            assertThat(result).isEqualTo(products);
+        }
+
+        @Test
+        void condition_null_예외() {
+            Pageable pageable = PageRequest.of(0, 10);
+            assertThrows(CoreException.class, () -> productService.search(null, pageable));
+        }
+
+        @Test
+        void pageable_null_예외() {
+            ProductSearchCondition condition = mock(ProductSearchCondition.class);
+            assertThrows(CoreException.class, () -> productService.search(condition, null));
+        }
+    }
+
+    @Nested
+    @DisplayName("countAll")
+    class CountAll {
+        @Test
+        void 정상_조회() {
+            ProductSearchCondition condition = mock(ProductSearchCondition.class);
+            when(productRepository.getTotalAmount(condition)).thenReturn(5L);
+
+            long count = productService.countAll(condition);
+
+            assertThat(count).isEqualTo(5L);
+        }
+
+        @Test
+        void condition_null_예외() {
+            assertThrows(CoreException.class, () -> productService.countAll(null));
+        }
+    }
+
+    @Nested
+    @DisplayName("getProducts")
+    class GetProducts {
+        @Test
+        void 정상_조회() {
+            Set<Long> ids = Set.of(1L, 2L);
+            List<ProductModel> products = List.of(mock(ProductModel.class));
+            when(productRepository.findAll(ids)).thenReturn(products);
+
+            List<ProductModel> result = productService.getProducts(ids);
+
+            assertThat(result).isEqualTo(products);
+        }
+
+        @Test
+        void ids_null_예외() {
+            assertThrows(CoreException.class, () -> productService.getProducts(null));
+        }
+
+        @Test
+        void ids_empty_빈리스트() {
+            List<ProductModel> result = productService.getProducts(Collections.emptySet());
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("getDetail")
+    class GetDetail {
+        @Test
+        void 정상_조회() {
+            ProductModel product = mock(ProductModel.class);
+            when(productRepository.find(1L)).thenReturn(Optional.of(product));
+
+            ProductModel result = productService.getDetail(1L);
+
+            assertThat(result).isEqualTo(product);
+        }
+
+        @Test
+        void id_null_예외() {
+            assertThrows(CoreException.class, () -> productService.getDetail(null));
+        }
+
+        @Test
+        void 존재하지않는_상품_예외() {
+            when(productRepository.find(1L)).thenReturn(Optional.empty());
+            CoreException ex = assertThrows(CoreException.class, () -> productService.getDetail(1L));
+            assertThat(ex.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateProductLikeCount")
+    class UpdateProductLikeCount {
+        @Test
+        void 정상_업데이트() {
+            ProductModel product = mock(ProductModel.class);
+            when(productRepository.save(product)).thenReturn(product);
+
+            ProductModel result = productService.updateProductLikeCount(product, 10L);
+
+            verify(product).updateLikeCount(10L);
+            verify(productRepository).save(product);
+            assertThat(result).isEqualTo(product);
+        }
+
+        @Test
+        void product_null_예외() {
+            assertThrows(CoreException.class, () -> productService.updateProductLikeCount(null, 1L));
+        }
+
+        @Test
+        void likeCount_null_예외() {
+            ProductModel product = mock(ProductModel.class);
+            assertThrows(CoreException.class, () -> productService.updateProductLikeCount(product, null));
+        }
+    }
+
+    @Nested
+    @DisplayName("decreaseStock")
+    class DecreaseStock {
+        @Test
+        void 정상_차감() {
+            ProductModel product = mock(ProductModel.class);
+            Stock stock = Stock.of(10L);
+            when(product.getStock()).thenReturn(stock);
+
+            productService.decreaseStock(product, 5L);
+
+            verify(product).decreaseStock(5L);
+            verify(productRepository).save(product);
+        }
+
+        @Test
+        void product_null_예외() {
+            assertThrows(CoreException.class, () -> productService.decreaseStock(null, 1L));
+        }
+
+        @Test
+        void quantity_0이하_예외() {
+            ProductModel product = mock(ProductModel.class);
+            assertThrows(CoreException.class, () -> productService.decreaseStock(product, 0L));
+        }
+
+        @Test
+        void 재고부족_예외() {
+            ProductModel product = mock(ProductModel.class);
+            when(product.getStock()).thenReturn(mock(Stock.class));
+            when(product.getStock().getQuantity()).thenReturn(2L);
+            when(product.getId()).thenReturn(1L);
+
+            CoreException ex = assertThrows(CoreException.class, () -> productService.decreaseStock(product, 5L));
+            assertThat(ex.getErrorType()).isEqualTo(ErrorType.CONFLICT);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/vo/PriceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/vo/PriceTest.java
@@ -1,0 +1,160 @@
+package com.loopers.domain.product.vo;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class PriceTest {
+
+    @DisplayName("가격을 생성할 때, ")
+    @Nested
+    class Create {
+        @DisplayName("null 이나 음수가 주어진 경우, 예외가 발생한다.")
+        @Test
+        void throwsException_whenAmountIsNullOrNegative() {
+            assertAll(
+                () -> {
+                    CoreException result = assertThrows(
+                        CoreException.class,
+                        () -> Price.of(null)
+                    );
+                    assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+                },
+                () -> {
+                    CoreException result = assertThrows(
+                        CoreException.class,
+                        () -> Price.of(new BigDecimal("-1"))
+                    );
+                    assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+                }
+            );
+        }
+    }
+
+    @DisplayName("가격을 더할 때, ")
+    @Nested
+    class Add {
+        @DisplayName("null 이 주어진 경우, 예외가 발생한다.")
+        @Test
+        void throwsException_whenAddingNullOrNegativePrice() {
+            Price price = Price.of(new BigDecimal("100"));
+
+            CoreException result = assertThrows(
+                CoreException.class,
+                () -> price.add(null)
+            );
+            assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+
+        @DisplayName("올바른 값이 주어지면, 정상적으로 가격을 더할 수 있다.")
+        @Test
+        void canAddPrices() {
+            Price price1 = Price.of(new BigDecimal("100"));
+            Price price2 = Price.of(new BigDecimal("50"));
+            Price result = price1.add(price2);
+
+            assertThat(result).isEqualTo(Price.of(new BigDecimal("150")));
+        }
+    }
+
+    @DisplayName("가격을 뺄 때, ")
+    @Nested
+    class Subtract {
+        @DisplayName("null 이 주어진 경우, 예외가 발생한다.")
+        @Test
+        void throwsException_whenSubtractingNull() {
+            Price price = Price.of(new BigDecimal("100"));
+
+            CoreException result = assertThrows(
+                CoreException.class,
+                () -> price.subtract(null)
+            );
+            assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+
+        @DisplayName("감소할 가격이 현재 가격보다 크면, 예외가 발생한다.")
+        @Test
+        void throwsException_whenSubtractingMoreThanCurrentPrice() {
+            Price price1 = Price.of(new BigDecimal("100"));
+            Price price2 = Price.of(new BigDecimal("150"));
+
+            CoreException result = assertThrows(
+                CoreException.class,
+                () -> price1.subtract(price2)
+            );
+            assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+
+        @DisplayName("올바른 값이 주어지면, 정상적으로 가격을 뺄 수 있다.")
+        @Test
+        void canSubtractPrices() {
+            Price price1 = Price.of(new BigDecimal("100"));
+            Price price2 = Price.of(new BigDecimal("50"));
+            Price result = price1.subtract(price2);
+
+            assertThat(result).isEqualTo(Price.of(new BigDecimal("50")));
+        }
+    }
+
+    @DisplayName("가격 비교를 할 때, ")
+    @Nested
+    class EqualsAndHashCode {
+        @DisplayName("같은 가격이면, 동일하게 취급된다.")
+        @Test
+        void equalsReturnsTrue_whenPriceIsEqual() {
+            Price price1 = Price.of(new BigDecimal("100"));
+            Price price2 = Price.of(new BigDecimal("100"));
+
+            assertThat(price1).isEqualTo(price2);
+        }
+
+        @DisplayName("다른 가격이면, equals 가 false 를 반환한다.")
+        @Test
+        void equalsReturnsFalse_whenPricesAreNotEqual() {
+            Price price1 = Price.of(new BigDecimal("100"));
+            Price price2 = Price.of(new BigDecimal("50"));
+
+            assertThat(price1).isNotEqualTo(price2);
+        }
+
+        @DisplayName("동일한 가격의 해시코드는 동일하다.")
+        @Test
+        void hashCodeIsSame_whenPricesAreEqual() {
+            Price price1 = Price.of(new BigDecimal("100"));
+            Price price2 = Price.of(new BigDecimal("100"));
+
+            assertThat(price1.hashCode()).isEqualTo(price2.hashCode());
+        }
+    }
+
+    @DisplayName("가격을 곱할 때, ")
+    @Nested
+    class Multiply {
+        @DisplayName("음수를 곱하면 예외가 발생한다.")
+        @Test
+        void throwsException_whenMultiplierIsNegative() {
+            Price price = Price.of(new BigDecimal("100"));
+            CoreException ex = assertThrows(
+                CoreException.class,
+                () -> price.multiply(-1)
+            );
+            assertThat(ex.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+
+        @DisplayName("0 또는 양수를 곱하면 정상적으로 곱해진다.")
+        @Test
+        void canMultiplyPrice() {
+            Price price = Price.of(new BigDecimal("100"));
+            assertThat(price.multiply(0)).isEqualTo(Price.of(BigDecimal.ZERO));
+            assertThat(price.multiply(3)).isEqualTo(Price.of(new BigDecimal("300")));
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/vo/StockTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/vo/StockTest.java
@@ -1,0 +1,75 @@
+package com.loopers.domain.product.vo;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class StockTest {
+
+    @DisplayName("재고를 생성할 때, ")
+    @Nested
+    class Create {
+        @DisplayName("음수의 수량이 주어지면, 예외가 발생한다.")
+        @Test
+        void throwsException_whenQuantityIsNegative() {
+            CoreException result = assertThrows(CoreException.class, () -> Stock.of(-1L));
+            assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+    }
+
+    @DisplayName("재고를 차감할 때, ")
+    @Nested
+    class Deduct {
+        @DisplayName("음수의 수량이 주어지면, 예외가 발생한다.")
+        @Test
+        void throwsException_whenDeductingNegativeQuantity() {
+            Stock stock = Stock.of(10L);
+            CoreException result = assertThrows(CoreException.class, () -> stock.deduct(-1L));
+            assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+
+        @DisplayName("재고보다 큰 수량을 차감하려고 하면, 예외가 발생한다.")
+        @Test
+        void throwsException_whenDeductingMoreThanAvailableStock() {
+            Stock stock = Stock.of(5L);
+            CoreException result = assertThrows(CoreException.class, () -> stock.deduct(10L));
+            assertThat(result.getErrorType()).isEqualTo(ErrorType.CONFLICT);
+        }
+    }
+
+    @DisplayName("재고를 비교할 때, ")
+    @Nested
+    class EqualsAndHashCode {
+        @DisplayName("같은 수량의 재고는 동일하게 취급된다.")
+        @Test
+        void equalsReturnsTrue_whenStockIsEqual() {
+            Stock stock1 = Stock.of(10L);
+            Stock stock2 = Stock.of(10L);
+
+            assertThat(stock1).isEqualTo(stock2);
+        }
+
+        @DisplayName("다른 수량의 재고는 동일하지 않게 취급된다.")
+        @Test
+        void equalsReturnsFalse_whenStockIsNotEqual() {
+            Stock stock1 = Stock.of(10L);
+            Stock stock2 = Stock.of(5L);
+
+            assertThat(stock1).isNotEqualTo(stock2);
+        }
+
+        @DisplayName("동일한 재고의 해시코드는 동일하다.")
+        @Test
+        void hashCodeIsSame_whenStocksAreEqual() {
+            Stock stock1 = Stock.of(10L);
+            Stock stock2 = Stock.of(10L);
+
+            assertThat(stock1.hashCode()).isEqualTo(stock2.hashCode());
+        }
+    }
+}


### PR DESCRIPTION
## 📌 Summary

타 도메인 간에는 JOIN 보다는 최대한 아이디 기반으로 주고 받으면서 어플리케이션 서비스 레이어에서 여러 도메인 조합하고자 했습니다. 종속적인 도메인은 (예: 주문과 주문 아이템)에 대해서는 OneToMany 등 연관관계 맺어서 처리하는 것을 허용했습니다.
도메인 서비스는 하나의 레포지토리 인터페이스만 책임지는 형태로 구현했습니다. 동일한 명칭의 VO여도 사용 도메인이 다르면 구분지어서 관리했고, 레포지토리 구현체는 jpa 및 querydsl 기반으로 구현 했습니다. 어플리케이션 서비스 레이어는 유즈 케이스 별로 구분해서 하나씩 별도로 만들었으며, 특히 쿼리와 커맨드를 미리 구분지어서 작업했습니다.

## 💬 Review Points

(1) 도메인 모델 별로 레포지토리 인터페이스 선언했어야 했을까요?
OrderRepository에서 Order와 그 하위 엔티티(OrderItem 등)를 일괄 관리
vs OrderRepository와 OrderItemRepository 분리해서 관리

(2) Specification 패턴을 배워서 사용해 봤는데 올바르게 적용했을까요?
원래 ProductService에는 search(pageable), search(brandId, pageable) 이렇게 오버로딩해서 사용했는데
이러한 구조는 쿼리 조건이 늘어나면 매번 오버로딩을 해야할 것 같아서 Specification 패턴에서 착안해서
하나의 인자 타입으로 여러 쿼리 조건을 컨트롤 할 수 있는 코드를 작성하고자 노력했지만,
결국 Specification과 querydsl QModel의 Predicate와 연결해서 사용하지는 못하고 약간의 개선만 시켰습니다.
 Specification으로 and, or, not 체이닝을 통해 최종적으로 querydsl QModel의 Predicates로 연결/변환 시킬려면 어떻게 했어야 했을까요? 그리고 검색 조건 별로 search 오버로딩하는 방식에 대해 어떻게 생각하시나요?

(3) 어플리케이션 서비스 (usecase)와 도메인 서비스 (/domain/*) 평가 요청 건
저 두가지를 올바르게 구분지어서 사용했는지 그리고 개선점 피드백 요청 드립니다. 
저는 applicaiton service -> domain service -> repository <- repositoryImpl 이런 방향으로 작업을 하긴 했는데, 
예를 들어 항상 도메인 모델의 행위를 도메인 서비스로 감싸서, 어플리케이션 서비스에서는 도메인 서비스를 통해 도메인 모델의 행위/액선을 제공받도록 해야할까요? 처음에는 어플리케이션 서비스에서 도메인 모델 불러와서 model.action() 이런식의 호출 부분이 충분히 있을 것 같다고 생각했는데 정작 도메인 서비스에서 영속화 책임까지 다 해결해줘서 어플리케이션 서비스에 제공하는 구조로 코드 작성을 진행하다보니까 순수하게 도메인 모델 불러와서 도메인 서비스 없이 어떤 "책임 수행/메서드 호출" 시키는 일이 거의 없어지더라구요.
제가 서비스 별 역할과 책임을 잘못 이해하고 사용한 것일까요? (= 도메인 서비스가 영속화 관련 처리까지 다 해결해주는게 올바른가?) 

(4) 네이밍 룰 추천 혹은 관례에 대한 건
repository, domain service, application service 에서 메서드 네이밍에 관한 멘토님의 룰이나 선호하는 방식이 있을까요?
작업 중 블록킹 포인트였던 부분이 repository.findAll 이런 이름을 썼을 때 이 이름 그대로 bypass해서 domainService.findAll, QueryFindAllUseCase (유즈케이스는 극단적 예시입니다) 처럼 특히 조회 쪽 이름 지을 때 repository인지 domainService인지 applicationService 인지에 따라 의식하지 않으면 이름을 그대로 사용하려는 자신을 발견했습니다. 개인적으로는 레이어(repository, domain, applicaiton)에 따라 네이밍 룰이 약간 다르게 적용할 수 있지 않을까 싶은데 기준이 없어서 고민입니다.  

(5) VO 및 DTO 관련 질문
현재 주문이랑 상품에서 Price라는 VO를 "동일한 명칭"으로 서로 다른 클래스로써 구분지어 관리하고 있는데 이거 합치는게 더 좋았을까요? 타입이 달라 서로 간에 변환하는 코드도 사용성에 있어서 상당히 번거롭다고 느끼긴 했습니다. 그래도 도메인 간 격리/독립성 높이고자 서로 다른 도메인 간에 import 하는 일을 최대한 피하는 게 좋은지 궁금합니다. 
추가로, repository의 인자로 타 도메인 정보 필요할 때, 도메인 모델 vs 도메인 모델의 아이디 어떤 형태로 전달 받는 것이 더 좋을까요? 
도메인 모델을 인자로 받는 순간 레포지토리가 책임지던 도메인 영역의 순수성을 헤치게 될까요? 
요지는 도메인 패키지 별로 그들이 책임지는 도메인 영역의 순수성을 훼손시키지 않는 게 좋을 것 같은데 타 도메인 패키지에 있는 모델 클래스라던지, VO 클래스라던지, DTO 클래스라던지를 마음껏 import 해오면 도메인의 영역이 흐릿해지고 뒤섞이는 암울한 미래가 펼쳐질까요? 물론 도메인 서비스나 어플리케이션 서비스는 여러 도메인을 조율하는 역할이다보니 허용한다 치더라도 도메인 패키지 내부의 다른 클래스에서도 이래도 되는가 싶었습니다. 

## ✅ Checklist

🏷 Product / Brand 도메인

- [x]  상품 정보 객체는 브랜드 정보, 좋아요 수를 포함한다.
- [x]  상품의 정렬 조건(`latest`, `price_asc`, `likes_desc`) 을 고려한 조회 기능을 설계했다
- [x]  상품은 재고를 가지고 있고, 주문 시 차감할 수 있어야 한다
- [x]  재고는 감소만 가능하며 음수 방지는 도메인 레벨에서 처리된다

### 👍 Like 도메인

- [x]  좋아요는 유저와 상품 간의 관계로 별도 도메인으로 분리했다
- [x]  중복 좋아요 방지를 위한 멱등성 처리가 구현되었다
- [x]  상품의 좋아요 수는 상품 상세/목록 조회에서 함께 제공된다
- [x]  단위 테스트에서 좋아요 등록/취소/중복 방지 흐름을 검증했다

### 🛒 Order 도메인

- [x]  주문은 여러 상품을 포함할 수 있으며, 각 상품의 수량을 명시한다
- [x]  주문 시 상품의 재고 차감, 유저 포인트 차감 등을 수행한다
- [x]  재고 부족, 포인트 부족 등 예외 흐름을 고려해 설계되었다
- [x]  단위 테스트에서 정상 주문 / 예외 주문 흐름을 모두 검증했다

### 🧩 도메인 서비스

- [x]  도메인 간 협력 로직은 Domain Service에 위치시켰다
- [x]  상품 상세 조회 시 Product + Brand 정보 조합은 도메인 서비스에서 처리했다
- [x]  복합 유스케이스는 Application Layer에 존재하고, 도메인 로직은 위임되었다
- [x]  도메인 서비스는 상태 없이, 도메인 객체의 협력 중심으로 설계되었다

### **🧱 소프트웨어 아키텍처 & 설계**

- [x]  전체 프로젝트의 구성은 아래 아키텍처를 기반으로 구성되었다
    - Application → **Domain** ← Infrastructure
- [x]  Application Layer는 도메인 객체를 조합해 흐름을 orchestration 했다
- [x]  핵심 비즈니스 로직은 Entity, VO, Domain Service 에 위치한다
- [x]  Repository Interface는 Domain Layer 에 정의되고, 구현체는 Infra에 위치한다
- [x]  패키지는 계층 + 도메인 기준으로 구성되었다 (`/domain/order`, `/application/like` 등)
- [x]  테스트는 외부 의존성을 분리하고, Fake/Stub 등을 사용해 단위 테스트가 가능하게 구성되었다