### PR TITLE
동시성 테스트 구현

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/like/usecase/command/CommandMarkLikeUseCase.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/usecase/command/CommandMarkLikeUseCase.java
@@ -9,6 +9,7 @@ import com.loopers.domain.product.ProductService;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,7 +30,10 @@ public class CommandMarkLikeUseCase {
         MemberModel member = memberService.getMember(command.memberInfo.userId());
         ProductModel product = productService.getDetail(command.productId());
 
-        likeService.like(member, product);
+        try {
+            likeService.like(member, product);
+        } catch (DataIntegrityViolationException _) {
+        }
 
         productService.updateProductLikeCount(product, likeService.getLikeCount(product));
     }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeRepository.java
@@ -18,4 +18,6 @@ public interface LikeRepository {
     List<LikeModel> search(MemberModel member, Pageable pageable);
 
     long countMemberLikedProducts(Long memberId);
+
+    Optional<LikeModel> findWithLock(Long memberId, Long productId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
@@ -37,7 +37,7 @@ public class LikeService {
             throw new CoreException(ErrorType.BAD_REQUEST, "Member and Product cannot be null");
         }
 
-        Optional<LikeModel> like = likeRepository.find(member.getId(), product.getId());
+        Optional<LikeModel> like = likeRepository.findWithLock(member.getId(), product.getId());
         like.ifPresent(likeRepository::delete);
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
@@ -7,6 +7,8 @@ import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -17,12 +19,14 @@ public class LikeService {
 
     private final LikeRepository likeRepository;
 
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void like(MemberModel member, ProductModel product) {
         if (member == null || product == null) {
             throw new CoreException(ErrorType.BAD_REQUEST, "Member and Product cannot be null");
         }
 
         Optional<LikeModel> like = likeRepository.find(member.getId(), product.getId());
+
         if (like.isEmpty()) {
             likeRepository.save(new LikeModel(member.getId(), product.getId()));
         }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/member/MemberModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/member/MemberModel.java
@@ -6,7 +6,6 @@ import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import jakarta.persistence.*;
 import lombok.Getter;
-import org.hibernate.annotations.ColumnDefault;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
@@ -31,9 +30,8 @@ public class MemberModel extends BaseEntity {
     @Getter
     private Long points;
 
-    @Version
     @Getter
-    @ColumnDefault("0")
+    @Version
     private Long version;
 
     protected MemberModel() {
@@ -77,7 +75,7 @@ public class MemberModel extends BaseEntity {
         this.birthdate = parsedBirthdate;
         this.email = email;
         this.points = points;
-        this.version = 0L;
+        this.version = null;
     }
 
     public Long chargePoints(Long amount) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/member/MemberModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/member/MemberModel.java
@@ -4,10 +4,9 @@ import com.loopers.domain.BaseEntity;
 import com.loopers.domain.member.enums.Gender;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.hibernate.annotations.ColumnDefault;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
@@ -16,16 +15,26 @@ import java.time.format.DateTimeParseException;
 @Table(name = "member")
 public class MemberModel extends BaseEntity {
 
+    @Getter
     private String userId;
 
     @Enumerated(EnumType.STRING)
+    @Getter
     private Gender gender;
 
+    @Getter
     private LocalDate birthdate;
 
+    @Getter
     private String email;
 
+    @Getter
     private Long points;
+
+    @Version
+    @Getter
+    @ColumnDefault("0")
+    private Long version;
 
     protected MemberModel() {
     }
@@ -68,26 +77,7 @@ public class MemberModel extends BaseEntity {
         this.birthdate = parsedBirthdate;
         this.email = email;
         this.points = points;
-    }
-
-    public String getUserId() {
-        return userId;
-    }
-
-    public Gender getGender() {
-        return gender;
-    }
-
-    public LocalDate getBirthdate() {
-        return birthdate;
-    }
-
-    public String getEmail() {
-        return email;
-    }
-
-    public Long getPoints() {
-        return points;
+        this.version = 0L;
     }
 
     public Long chargePoints(Long amount) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/orders/OrderService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/orders/OrderService.java
@@ -29,6 +29,7 @@ public class OrderService {
             .reduce(BigDecimal.ZERO, BigDecimal::add));
 
         OrdersModel order = new OrdersModel(member.getId(), totalPrice);
+        OrdersModel savedOrder = orderRepository.save(order);
 
         for (Pair<ProductModel, Long> pair : products) {
             ProductModel product = pair.getFirst();
@@ -39,15 +40,14 @@ public class OrderService {
             }
 
             OrderItemModel item = new OrderItemModel(
-                order,
+                savedOrder,
                 ProductSnapshot.of(product.getId(), product.getName(), Price.of(product.getPrice().getAmount())),
                 quantity
             );
-            order.addItem(item);
+            savedOrder.addItem(item);
         }
 
-        OrdersModel savedOrder = orderRepository.save(order);
-        orderRepository.saveAll(order.getItems());
+        orderRepository.saveAll(savedOrder.getItems());
         return savedOrder;
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
@@ -17,4 +17,6 @@ public interface ProductRepository {
     Optional<ProductModel> find(Long productId);
 
     ProductModel save(ProductModel product);
+
+    Optional<ProductModel> findWithLock(Long productId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.loopers.domain.like.LikeModel;
 import com.loopers.domain.like.LikeRepository;
 import com.loopers.domain.member.MemberModel;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.LockModeType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
@@ -25,6 +26,7 @@ public class LikeRepositoryImpl implements LikeRepository {
         return Optional.ofNullable(
             queryFactory.selectFrom(likeModel)
                 .where(likeModel.memberId.eq(memberId).and(likeModel.productId.eq(productId)))
+                .setLockMode(LockModeType.PESSIMISTIC_WRITE)
                 .fetchOne()
         );
     }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeRepositoryImpl.java
@@ -26,7 +26,6 @@ public class LikeRepositoryImpl implements LikeRepository {
         return Optional.ofNullable(
             queryFactory.selectFrom(likeModel)
                 .where(likeModel.memberId.eq(memberId).and(likeModel.productId.eq(productId)))
-                .setLockMode(LockModeType.PESSIMISTIC_WRITE)
                 .fetchOne()
         );
     }
@@ -67,5 +66,15 @@ public class LikeRepositoryImpl implements LikeRepository {
             .where(likeModel.memberId.eq(memberId))
             .fetchOne();
         return count != null ? count : 0L;
+    }
+
+    @Override
+    public Optional<LikeModel> findWithLock(Long memberId, Long productId) {
+        return Optional.ofNullable(
+            queryFactory.selectFrom(likeModel)
+                .where(likeModel.memberId.eq(memberId).and(likeModel.productId.eq(productId)))
+                .setLockMode(LockModeType.PESSIMISTIC_WRITE)
+                .fetchOne()
+        );
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
@@ -10,6 +10,7 @@ import com.loopers.support.error.ErrorType;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.LockModeType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort.Direction;
@@ -103,5 +104,14 @@ public class ProductRepositoryImpl implements ProductRepository {
             case LIKES -> direction.isAscending() ? productModel.likeCount.asc() : productModel.likeCount.desc();
             case PRICE -> direction.isAscending() ? productModel.price.amount.asc() : productModel.price.amount.desc();
         };
+    }
+
+    @Override
+    public Optional<ProductModel> findWithLock(Long productId) {
+        return Optional.ofNullable(queryFactory.selectFrom(productModel)
+            .where(productModel.id.eq(productId))
+            .setLockMode(LockModeType.PESSIMISTIC_WRITE)
+            .fetchOne()
+        );
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/application/like/usecase/command/CommandMarkLikeUseCaseTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/like/usecase/command/CommandMarkLikeUseCaseTest.java
@@ -1,0 +1,84 @@
+package com.loopers.application.like.usecase.command;
+
+import com.loopers.application.like.usecase.command.CommandMarkLikeUseCase.Command;
+import com.loopers.application.member.MemberInfo;
+import com.loopers.domain.like.LikeRepository;
+import com.loopers.domain.member.enums.Gender;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.time.LocalDate;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+class CommandMarkLikeUseCaseTest {
+
+    @Autowired
+    private CommandMarkLikeUseCase commandMarkLikeUseCase;
+
+    @Autowired
+    private LikeRepository likeRepository;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @Test
+    @Sql(statements = {
+        "INSERT INTO product (id, name, price, stock, brand_id, like_count, created_at, updated_at, deleted_at) VALUES (1, '테스트상품1', 1000, 15, 1, 10, '2023-10-01 00:00:00', '2023-10-01 00:00:00', NULL)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at) VALUES (1, 'testUser', 'MALE', 'test@test.com', '2024-01-01', 0, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL)"
+    })
+    void 멱등성_동시에_요청해도_하나만_반영한다() throws InterruptedException {
+        int threadCount = 5;
+        MemberInfo memberInfo = new MemberInfo(
+            1L,
+            "testUser",
+            Gender.MALE,
+            LocalDate.of(2024, 1, 1),
+            "test@test.com",
+            0L
+        );
+        Long productId = 1L;
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failureCount = new AtomicInteger();
+
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    commandMarkLikeUseCase.execute(new Command(memberInfo, productId));
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    System.err.println("Error: " + e.getClass().getName());
+                    System.err.println("Error: " + e.getClass());
+                    failureCount.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        long likeCount = likeRepository.getProductLikeCount(productId);
+
+        assertThat(successCount.get()).isEqualTo(threadCount);
+        assertThat(likeCount).isEqualTo(1);
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/application/like/usecase/command/CommandMarkLikeUseCaseTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/like/usecase/command/CommandMarkLikeUseCaseTest.java
@@ -39,7 +39,7 @@ class CommandMarkLikeUseCaseTest {
     @Test
     @Sql(statements = {
         "INSERT INTO product (id, name, price, stock, brand_id, like_count, created_at, updated_at, deleted_at) VALUES (1, '테스트상품1', 1000, 15, 1, 10, '2023-10-01 00:00:00', '2023-10-01 00:00:00', NULL)",
-        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at) VALUES (1, 'testUser', 'MALE', 'test@test.com', '2024-01-01', 0, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL)"
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (1, 'testUser', 'MALE', 'test@test.com', '2024-01-01', 0, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)"
     })
     void 멱등성_동시에_요청해도_하나만_반영한다() throws InterruptedException {
         int threadCount = 5;

--- a/apps/commerce-api/src/test/java/com/loopers/application/like/usecase/command/CommandUnmarkLikeUseCaseTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/like/usecase/command/CommandUnmarkLikeUseCaseTest.java
@@ -69,7 +69,6 @@ class CommandUnmarkLikeUseCaseTest {
                     commandUnmarkLikeUseCase.execute(new CommandUnmarkLikeUseCase.Command(memberInfo, productId));
                     successCount.incrementAndGet();
                 } catch (Exception e) {
-                    System.err.println(e.getClass().getName() + ": " + e.getCause().getClass().getName());
                     failureCount.incrementAndGet();
                 } finally {
                     latch.countDown();

--- a/apps/commerce-api/src/test/java/com/loopers/application/like/usecase/command/CommandUnmarkLikeUseCaseTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/like/usecase/command/CommandUnmarkLikeUseCaseTest.java
@@ -38,9 +38,9 @@ class CommandUnmarkLikeUseCaseTest {
     @Test
     @Sql(statements = {
         "INSERT INTO product (id, name, price, stock, brand_id, like_count, created_at, updated_at, deleted_at) VALUES (1, '테스트상품1', 1000, 15, 1, 3, '2023-10-01 00:00:00', '2023-10-01 00:00:00', NULL)",
-        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at) VALUES (1, 'testUser1', 'MALE', 'test@test.com', '2024-01-01', 0, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL)",
-        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at) VALUES (2, 'testUser2', 'MALE', 'test@test.com', '2024-01-01', 0, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL)",
-        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at) VALUES (3, 'testUser3', 'MALE', 'test@test.com', '2024-01-01', 0, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (1, 'testUser1', 'MALE', 'test@test.com', '2024-01-01', 0, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (2, 'testUser2', 'MALE', 'test@test.com', '2024-01-01', 0, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (3, 'testUser3', 'MALE', 'test@test.com', '2024-01-01', 0, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)",
         "insert into likes (created_at, member_id, product_id) values ('2023-10-01 12:00:00', 1, 1);",
         "insert into likes (created_at, member_id, product_id) values ('2023-10-01 12:00:00', 2, 1);",
         "insert into likes (created_at, member_id, product_id) values ('2023-10-01 12:00:00', 3, 1);"

--- a/apps/commerce-api/src/test/java/com/loopers/application/orders/usecase/command/CommandOrderUseCaseTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/orders/usecase/command/CommandOrderUseCaseTest.java
@@ -4,6 +4,8 @@ import com.loopers.application.member.MemberInfo;
 import com.loopers.domain.member.MemberModel;
 import com.loopers.domain.member.MemberRepository;
 import com.loopers.domain.member.enums.Gender;
+import com.loopers.domain.product.ProductModel;
+import com.loopers.domain.product.ProductRepository;
 import com.loopers.utils.DatabaseCleanUp;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -30,6 +32,9 @@ class CommandOrderUseCaseTest {
     private MemberRepository memberRepository;
 
     @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
     private DatabaseCleanUp databaseCleanUp;
 
     @AfterEach
@@ -45,7 +50,7 @@ class CommandOrderUseCaseTest {
         "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (1, 'testUser', 'MALE', 'test@test.com', '2024-01-01', 10000, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)"
     })
     void 동일한_유저가_여러_기기에서_동시에_주문해도_포인트가_중복_차감되지_않아야_한다() throws InterruptedException {
-        int threadCount = 20;
+        final int threadCount = 20;
         MemberInfo memberInfo = new MemberInfo(
             1L,
             "testUser",
@@ -83,5 +88,55 @@ class CommandOrderUseCaseTest {
         assertThat(failureCount.get()).isEqualTo(19);
         assertThat(successCount.get()).isEqualTo(1);
         assertThat(member.getPoints()).isEqualTo(4000L);
+    }
+
+    @Test
+    @Sql(statements = {
+        "INSERT INTO product (id, name, price, stock, brand_id, like_count, created_at, updated_at, deleted_at) VALUES (1, '테스트상품1', 1000, 15, 1, 10, '2023-10-01 00:00:00', '2023-10-01 00:00:00', NULL)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (1, 'testUser1', 'MALE', 'test@test.com', '2024-01-01', 10000, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (2, 'testUser2', 'MALE', 'test@test.com', '2024-01-01', 10000, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (3, 'testUser3', 'MALE', 'test@test.com', '2024-01-01', 10000, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (4, 'testUser4', 'MALE', 'test@test.com', '2024-01-01', 10000, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (5, 'testUser5', 'MALE', 'test@test.com', '2024-01-01', 10000, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)"
+    })
+    void 동일한_상품에_대해_여러_주문이_동시에_요청되어도_재고가_정상적으로_차감되어야_한다() throws InterruptedException {
+        final int threadCount = 5;
+        MemberModel m1 = memberRepository.findByUserId("testUser1").orElseThrow();
+        MemberModel m2 = memberRepository.findByUserId("testUser2").orElseThrow();
+        MemberModel m3 = memberRepository.findByUserId("testUser3").orElseThrow();
+        MemberModel m4 = memberRepository.findByUserId("testUser4").orElseThrow();
+        MemberModel m5 = memberRepository.findByUserId("testUser5").orElseThrow();
+
+        List<MemberInfo> memberInfos = List.of(MemberInfo.from(m1), MemberInfo.from(m2), MemberInfo.from(m3), MemberInfo.from(m4), MemberInfo.from(m5));
+        List<Long> productIds = List.of(1L);
+        List<Long> quantities = List.of(2L);
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failureCount = new AtomicInteger();
+
+        for (int i = 0; i < threadCount; i++) {
+            final int memberIndex = i % memberInfos.size();
+            executor.submit(() -> {
+                try {
+                    commandOrderUseCase.execute(new CommandOrderUseCase.Command(memberInfos.get(memberIndex), productIds, quantities));
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failureCount.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        ProductModel productModel = productRepository.find(1L).orElseThrow();
+        assertThat(productModel.getStock().getQuantity()).isEqualTo(5L);
+
+        assertThat(failureCount.get()).isEqualTo(0);
+        assertThat(successCount.get()).isEqualTo(threadCount);
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/application/orders/usecase/command/CommandOrderUseCaseTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/orders/usecase/command/CommandOrderUseCaseTest.java
@@ -1,0 +1,87 @@
+package com.loopers.application.orders.usecase.command;
+
+import com.loopers.application.member.MemberInfo;
+import com.loopers.domain.member.MemberModel;
+import com.loopers.domain.member.MemberRepository;
+import com.loopers.domain.member.enums.Gender;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+class CommandOrderUseCaseTest {
+
+    @Autowired
+    private CommandOrderUseCase commandOrderUseCase;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @Test
+    @Sql(statements = {
+        "INSERT INTO product (id, name, price, stock, brand_id, like_count, created_at, updated_at, deleted_at) VALUES (1, '테스트상품1', 1000, 15, 1, 10, '2023-10-01 00:00:00', '2023-10-01 00:00:00', NULL)",
+        "INSERT INTO product (id, name, price, stock, brand_id, like_count, created_at, updated_at, deleted_at) VALUES (2, '테스트상품2', 2000, 10, 1, 10, '2023-10-01 00:00:00', '2023-10-01 00:00:00', NULL)",
+        "INSERT INTO product (id, name, price, stock, brand_id, like_count, created_at, updated_at, deleted_at) VALUES (3, '테스트상품3', 3000, 5, 1, 10, '2023-10-01 00:00:00', '2023-10-01 00:00:00', NULL)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at) VALUES (1, 'testUser', 'MALE', 'test@test.com', '2024-01-01', 10000, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL)"
+    })
+    void 동일한_유저가_여러_기기에서_동시에_주문해도_포인트가_중복_차감되지_않아야_한다() throws InterruptedException {
+        int threadCount = 20;
+        MemberInfo memberInfo = new MemberInfo(
+            1L,
+            "testUser",
+            Gender.MALE,
+            LocalDate.of(2024, 1, 1),
+            "test@test.com",
+            10000L
+        );
+        List<Long> productIds = List.of(1L, 2L, 3L);
+        List<Long> quantities = List.of(1L, 1L, 1L);
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failureCount = new AtomicInteger();
+
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    commandOrderUseCase.execute(new CommandOrderUseCase.Command(memberInfo, productIds, quantities));
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failureCount.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        MemberModel member = memberRepository.findByUserId("testUser").orElseThrow();
+
+        assertThat(failureCount.get()).isEqualTo(19);
+        assertThat(successCount.get()).isEqualTo(1);
+        assertThat(member.getPoints()).isEqualTo(4000L);
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/application/orders/usecase/command/CommandOrderUseCaseTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/orders/usecase/command/CommandOrderUseCaseTest.java
@@ -42,7 +42,7 @@ class CommandOrderUseCaseTest {
         "INSERT INTO product (id, name, price, stock, brand_id, like_count, created_at, updated_at, deleted_at) VALUES (1, '테스트상품1', 1000, 15, 1, 10, '2023-10-01 00:00:00', '2023-10-01 00:00:00', NULL)",
         "INSERT INTO product (id, name, price, stock, brand_id, like_count, created_at, updated_at, deleted_at) VALUES (2, '테스트상품2', 2000, 10, 1, 10, '2023-10-01 00:00:00', '2023-10-01 00:00:00', NULL)",
         "INSERT INTO product (id, name, price, stock, brand_id, like_count, created_at, updated_at, deleted_at) VALUES (3, '테스트상품3', 3000, 5, 1, 10, '2023-10-01 00:00:00', '2023-10-01 00:00:00', NULL)",
-        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at) VALUES (1, 'testUser', 'MALE', 'test@test.com', '2024-01-01', 10000, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL)"
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (1, 'testUser', 'MALE', 'test@test.com', '2024-01-01', 10000, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)"
     })
     void 동일한_유저가_여러_기기에서_동시에_주문해도_포인트가_중복_차감되지_않아야_한다() throws InterruptedException {
         int threadCount = 20;

--- a/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeServiceTest.java
@@ -64,7 +64,7 @@ class LikeServiceTest {
         LikeModel like = mock(LikeModel.class);
         when(member.getId()).thenReturn(1L);
         when(product.getId()).thenReturn(2L);
-        when(likeRepository.find(1L, 2L)).thenReturn(Optional.of(like));
+        when(likeRepository.findWithLock(1L, 2L)).thenReturn(Optional.of(like));
 
         likeService.unlike(member, product);
 
@@ -75,9 +75,7 @@ class LikeServiceTest {
     void unlike_좋아요없으면_delete_호출안함() {
         MemberModel member = mock(MemberModel.class);
         ProductModel product = mock(ProductModel.class);
-        when(member.getId()).thenReturn(1L);
-        when(product.getId()).thenReturn(2L);
-        when(likeRepository.find(1L, 2L)).thenReturn(Optional.empty());
+        when(likeRepository.findWithLock(any(), any())).thenReturn(Optional.empty());
 
         likeService.unlike(member, product);
 


### PR DESCRIPTION
## 📌 Summary

동시성 상황에서 좋아요와 싫어요 요청에 대해 멱등성과 좋아요 갯수 정상 반영 검증
동시성 상황에서 주문 시 회원의 포인트 중복 차감 방지 및 재고 정상 차감 검증

## ✅ Checklist

### 동시성 테스트

- [x]  동일한 상품에 대해 여러명이 좋아요/싫어요를 요청해도, 상품의 좋아요 개수가 정상 반영되어야 한다.
- [x]  동일한 유저가 여러 기기에서 동시에 주문에도, 포인트가 중복 차감되지 않아야 한다.
- [x]  동일한 상품에 대해 여러 주문이 동시에 요청되어도, 재고가 정상적으로 차감되어야 한다.