### PR TITLE
feat: 쿠폰 기능 추가 및 테스트 케이스 보충

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/like/usecase/command/CommandMarkLikeUseCase.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/usecase/command/CommandMarkLikeUseCase.java
@@ -32,7 +32,7 @@ public class CommandMarkLikeUseCase {
 
         try {
             likeService.like(member, product);
-        } catch (DataIntegrityViolationException _) {
+        } catch (DataIntegrityViolationException e) {
         }
 
         productService.updateProductLikeCount(product, likeService.getLikeCount(product));

--- a/apps/commerce-api/src/main/java/com/loopers/application/orders/dto/OrderInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/orders/dto/OrderInfo.java
@@ -7,16 +7,17 @@ import com.loopers.support.error.ErrorType;
 import java.math.BigDecimal;
 import java.util.List;
 
-public record OrderInfo(Long memberId, BigDecimal totalPrice, String status, List<OrderItemInfo> items) {
+public record OrderInfo(Long id, Long memberId, BigDecimal totalPrice, String status, List<OrderItemInfo> items) {
 
     public OrderInfo {
-        if (memberId == null || totalPrice == null || status == null || status.isBlank() || items == null || items.isEmpty()) {
+        if (id == null || memberId == null || totalPrice == null || status == null || status.isBlank() || items == null || items.isEmpty()) {
             throw new CoreException(ErrorType.BAD_REQUEST, "All fields must be provided and items cannot be empty");
         }
     }
 
     public static OrderInfo from(OrdersModel order) {
         return new OrderInfo(
+            order.getId(),
             order.getMemberId(),
             order.getTotalPrice().getAmount(),
             order.getStatus().name(),

--- a/apps/commerce-api/src/main/java/com/loopers/application/orders/usecase/command/CommandOrderUseCase.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/orders/usecase/command/CommandOrderUseCase.java
@@ -5,6 +5,7 @@ import com.loopers.application.orders.dto.OrderInfo;
 import com.loopers.domain.coupon.CouponModel;
 import com.loopers.domain.coupon.CouponRepository;
 import com.loopers.domain.member.MemberModel;
+import com.loopers.domain.member.MemberRepository;
 import com.loopers.domain.member.MemberService;
 import com.loopers.domain.orders.ExternalServiceOutputPort;
 import com.loopers.domain.orders.OrderService;
@@ -33,10 +34,13 @@ public class CommandOrderUseCase {
     private final ExternalServiceOutputPort deliveryClient;
     private final ProductRepository productRepository;
     private final CouponRepository couponRepository;
+    private final MemberRepository memberRepository;
 
     @Transactional()
     public Result execute(Command command) {
-        MemberModel member = memberService.getMember(command.memberInfo().userId());
+        MemberModel member = memberRepository.findWithLock(command.memberInfo().id()).orElseThrow(
+            () -> new CoreException(ErrorType.NOT_FOUND, "Member not found with ID: " + command.memberInfo().id())
+        );
 
         CouponModel coupon = null;
         if (command.couponId() != null) {

--- a/apps/commerce-api/src/main/java/com/loopers/application/orders/usecase/command/CommandOrderUseCase.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/orders/usecase/command/CommandOrderUseCase.java
@@ -2,6 +2,8 @@ package com.loopers.application.orders.usecase.command;
 
 import com.loopers.application.member.MemberInfo;
 import com.loopers.application.orders.dto.OrderInfo;
+import com.loopers.domain.coupon.CouponModel;
+import com.loopers.domain.coupon.CouponRepository;
 import com.loopers.domain.member.MemberModel;
 import com.loopers.domain.member.MemberService;
 import com.loopers.domain.orders.ExternalServiceOutputPort;
@@ -20,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -30,10 +33,24 @@ public class CommandOrderUseCase {
     private final OrderService orderService;
     private final ExternalServiceOutputPort deliveryClient;
     private final ProductRepository productRepository;
+    private final CouponRepository couponRepository;
 
     @Transactional()
     public Result execute(Command command) {
         MemberModel member = memberService.getMember(command.memberInfo().userId());
+
+        Optional<CouponModel> coupon = couponRepository.find(command.couponId());
+        if (command.couponId() != null) {
+            if (coupon.isEmpty()) {
+                throw new CoreException(ErrorType.NOT_FOUND, "Coupon not found with ID: " + command.couponId());
+            }
+            if (coupon.get().getDeletedAt() != null) {
+                throw new CoreException(ErrorType.BAD_REQUEST, "사용할 수 없는 쿠폰입니다.");
+            }
+            if (coupon.get().getIssuedAt() == null || !coupon.get().hasOwned(member.getId())) {
+                throw new CoreException(ErrorType.BAD_REQUEST, "사용할 수 없는 쿠폰입니다.");
+            }
+        }
 
         List<Pair<ProductModel, Long>> items = new ArrayList<>();
         BigDecimal totalPrice = BigDecimal.ZERO;
@@ -52,11 +69,17 @@ public class CommandOrderUseCase {
             totalPrice = totalPrice.add(product.getPrice().multiply(quantity).getAmount());
         }
 
+        // 쿠폰 사용
+        if (coupon.isPresent()) {
+            totalPrice = coupon.get().apply(totalPrice);
+            couponRepository.saveAndFlush(coupon.get());
+        }
+
         // 포인트 차감
         memberService.payment(member, totalPrice);
 
         // 주문 상품 정보 저장
-        OrdersModel order = orderService.order(member, items);
+        OrdersModel order = orderService.order(member, items, coupon.map(CouponModel::getId).orElse(null));
 
         // 주문 정보 전송
         deliveryClient.send(order);
@@ -64,7 +87,7 @@ public class CommandOrderUseCase {
         return new Result(OrderInfo.from(order));
     }
 
-    public record Command(MemberInfo memberInfo, List<Long> productIds, List<Long> quantities) {
+    public record Command(MemberInfo memberInfo, List<Long> productIds, List<Long> quantities, Long couponId) {
     }
 
     public record Result(OrderInfo orderInfo) {

--- a/apps/commerce-api/src/main/java/com/loopers/application/orders/usecase/command/CommandOrderUseCase.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/orders/usecase/command/CommandOrderUseCase.java
@@ -86,7 +86,11 @@ public class CommandOrderUseCase {
         OrdersModel order = orderService.order(member, items, coupon != null ? coupon.getId() : null);
 
         // 주문 정보 전송
-        deliveryClient.send(order);
+        try {
+            deliveryClient.send(order);
+        } catch (Exception e) {
+            throw new CoreException(ErrorType.INTERNAL_ERROR, "Failed to process order: " + e.getMessage());
+        }
 
         return new Result(OrderInfo.from(order));
     }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponModel.java
@@ -1,0 +1,109 @@
+package com.loopers.domain.coupon;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "coupon")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CouponModel {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private final Long id = 0L;
+
+    @Column(unique = true, nullable = false, updatable = false)
+    @Getter
+    private String code;
+
+    @Embedded
+    @Getter
+    private DiscountMethod discountMethod;
+
+    @Column(name = "member_id")
+    @Getter
+    private Long memberId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "target_scope", nullable = false)
+    @Getter
+    private TargetScope targetScope;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private ZonedDateTime createdAt;
+
+    @Column(name = "issued_at")
+    @Getter
+    private ZonedDateTime issuedAt;
+
+    @Column(name = "deleted_at")
+    private ZonedDateTime deletedAt;
+
+    public CouponModel(DiscountMethod discountMethod, TargetScope targetScope) {
+        if (discountMethod == null || targetScope == null) {
+            throw new IllegalArgumentException("할인 방법과 대상 범위는 null 일 수 없습니다.");
+        }
+        this.code = UUID.randomUUID().toString();
+        this.discountMethod = discountMethod;
+        this.targetScope = targetScope;
+    }
+
+    public CouponModel(DiscountMethod discountMethod, TargetScope targetScope, Long memberId) {
+        if (discountMethod == null || targetScope == null || memberId == null) {
+            throw new IllegalArgumentException("할인 방법, 대상 범위, 회원 아이디는 null 일 수 없습니다.");
+        }
+        this.code = UUID.randomUUID().toString();
+        this.discountMethod = discountMethod;
+        this.targetScope = targetScope;
+        this.memberId = memberId;
+        this.issuedAt = ZonedDateTime.now();
+    }
+
+    public void issueTo(Long memberId) {
+        if (this.issuedAt != null) {
+            throw new IllegalStateException("이미 발급된 쿠폰입니다.");
+        }
+        this.memberId = memberId;
+        this.issuedAt = ZonedDateTime.now();
+    }
+
+    public BigDecimal apply(BigDecimal originalPrice) {
+        if (this.discountMethod == null) {
+            throw new IllegalStateException("할인 규칙이 설정되지 않았습니다.");
+        }
+        return this.discountMethod.toPolicy().applyDiscount(originalPrice);
+    }
+
+    @PrePersist
+    private void prePersist() {
+        this.createdAt = ZonedDateTime.now();
+    }
+
+    /**
+     * delete 연산은 멱등하게 동작할 수 있도록 한다. (삭제된 엔티티를 다시 삭제해도 동일한 결과가 나오도록)
+     */
+    public void delete() {
+        if (this.deletedAt == null) {
+            this.deletedAt = ZonedDateTime.now();
+        }
+    }
+
+    /**
+     * restore 연산은 멱등하게 동작할 수 있도록 한다. (삭제되지 않은 엔티티를 복원해도 동일한 결과가 나오도록)
+     */
+    public void restore() {
+        if (this.deletedAt != null) {
+            this.deletedAt = null;
+        }
+    }
+
+    public enum TargetScope {
+        ORDER
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponRepository.java
@@ -1,0 +1,9 @@
+package com.loopers.domain.coupon;
+
+import java.util.Optional;
+
+public interface CouponRepository {
+    Optional<CouponModel> find(Long id);
+
+    void saveAndFlush(CouponModel couponModel);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/DiscountMethod.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/DiscountMethod.java
@@ -1,0 +1,72 @@
+package com.loopers.domain.coupon;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DiscountMethod {
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "discount_type", nullable = false)
+    @Getter
+    private DiscountType discountType;
+
+    @Getter
+    private BigDecimal amount;
+
+    @Getter
+    private Double rate;
+
+    public DiscountMethod(BigDecimal amount) {
+        if (amount == null) {
+            throw new IllegalArgumentException("할인 금액은 null 일 수 없습니다.");
+        }
+
+        this.discountType = DiscountType.FIXED_AMOUNT;
+        this.amount = amount;
+    }
+
+    public DiscountMethod(Double rate) {
+        if (rate == null) {
+            throw new IllegalArgumentException("할인율은 null 일 수 없습니다.");
+        }
+
+        this.discountType = DiscountType.RATE;
+        this.rate = rate;
+    }
+
+    public DiscountPolicy toPolicy() {
+        if (discountType == null) {
+            throw new IllegalStateException("할인 유형이 설정되지 않았습니다.");
+        }
+        
+        switch (discountType) {
+            case FIXED_AMOUNT -> {
+                if (amount == null) {
+                    throw new IllegalArgumentException("할인 금액은 null 일 수 없습니다.");
+                }
+                return new FixedAmountPolicy(amount);
+            }
+            case RATE -> {
+                if (rate == null) {
+                    throw new IllegalArgumentException("할인율은 null 일 수 없습니다.");
+                }
+                return new RatePolicy(rate);
+            }
+            default -> throw new IllegalStateException("알 수 없는 할인 유형: " + discountType);
+        }
+    }
+
+    public enum DiscountType {
+        FIXED_AMOUNT, // 정액 할인
+        RATE // 정률 할인
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/DiscountPolicy.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/DiscountPolicy.java
@@ -1,0 +1,7 @@
+package com.loopers.domain.coupon;
+
+import java.math.BigDecimal;
+
+public interface DiscountPolicy {
+    BigDecimal applyDiscount(BigDecimal originalPrice);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/FixedAmountPolicy.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/FixedAmountPolicy.java
@@ -1,0 +1,20 @@
+package com.loopers.domain.coupon;
+
+import java.math.BigDecimal;
+
+public record FixedAmountPolicy(BigDecimal amount) implements DiscountPolicy {
+
+    public FixedAmountPolicy {
+        if (amount.compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException("고정 금액 할인 정책의 금액은 음수일 수 없습니다.");
+        }
+    }
+
+    @Override
+    public BigDecimal applyDiscount(BigDecimal originalPrice) {
+        if (originalPrice.compareTo(amount) < 0) {
+            return BigDecimal.ZERO;
+        }
+        return originalPrice.subtract(amount);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/RatePolicy.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/RatePolicy.java
@@ -1,0 +1,22 @@
+package com.loopers.domain.coupon;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+public record RatePolicy(double rate) implements DiscountPolicy {
+
+    public RatePolicy {
+        if (rate < 0 || rate > 1) {
+            throw new IllegalArgumentException("할인율은 0과 1 사이의 값이어야 합니다.");
+        }
+    }
+
+    @Override
+    public BigDecimal applyDiscount(BigDecimal originalPrice) {
+        if (originalPrice.compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException("원래 가격은 음수일 수 없습니다.");
+        }
+        BigDecimal discountAmount = originalPrice.multiply(BigDecimal.valueOf(rate));
+        return originalPrice.subtract(discountAmount).setScale(0, RoundingMode.CEILING);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/member/MemberRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/member/MemberRepository.java
@@ -8,4 +8,6 @@ public interface MemberRepository {
     MemberModel create(MemberModel member);
 
     MemberModel update(MemberModel member);
+
+    Optional<MemberModel> findWithLock(Long id);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/orders/OrderRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/orders/OrderRepository.java
@@ -12,4 +12,6 @@ public interface OrderRepository {
     List<OrdersModel> search(Long memberId);
 
     Optional<OrdersModel> find(Long orderId);
+
+    List<OrdersModel> searchByCoupon(Long couponId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/orders/OrderService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/orders/OrderService.java
@@ -19,7 +19,7 @@ public class OrderService {
 
     private final OrderRepository orderRepository;
 
-    public OrdersModel order(MemberModel member, List<Pair<ProductModel, Long>> products) {
+    public OrdersModel order(MemberModel member, List<Pair<ProductModel, Long>> products, Long couponId) {
         if (member == null || products == null || products.isEmpty()) {
             throw new CoreException(ErrorType.BAD_REQUEST, "Member and Products cannot be null or empty.");
         }
@@ -28,14 +28,14 @@ public class OrderService {
             .map(pair -> pair.getFirst().getPrice().multiply(pair.getSecond()).getAmount())
             .reduce(BigDecimal.ZERO, BigDecimal::add));
 
-        OrdersModel order = new OrdersModel(member.getId(), totalPrice);
+        OrdersModel order = new OrdersModel(member.getId(), totalPrice, couponId);
         OrdersModel savedOrder = orderRepository.save(order);
 
         for (Pair<ProductModel, Long> pair : products) {
             ProductModel product = pair.getFirst();
             Long quantity = pair.getSecond();
 
-            if (product == null || quantity == null || quantity <= 0) {
+            if (quantity <= 0) {
                 throw new CoreException(ErrorType.BAD_REQUEST, "Product and quantity must be valid.");
             }
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/orders/OrdersModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/orders/OrdersModel.java
@@ -37,6 +37,10 @@ public class OrdersModel extends BaseEntity {
     @Getter
     private Set<OrderItemModel> items = new LinkedHashSet<>();
 
+    public OrdersModel(Long memberId, Price totalPrice) {
+        this(memberId, totalPrice, null);
+    }
+
     public OrdersModel(Long memberId, Price totalPrice, Long couponId) {
         if (memberId == null) {
             throw new CoreException(ErrorType.BAD_REQUEST, "Member ID cannot be null.");

--- a/apps/commerce-api/src/main/java/com/loopers/domain/orders/OrdersModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/orders/OrdersModel.java
@@ -21,6 +21,9 @@ public class OrdersModel extends BaseEntity {
     @Getter
     private Long memberId;
 
+    @Getter
+    private Long couponId;
+
     @Embedded
     @AttributeOverride(name = "amount", column = @Column(name = "total_price"))
     @Getter
@@ -34,7 +37,7 @@ public class OrdersModel extends BaseEntity {
     @Getter
     private Set<OrderItemModel> items = new LinkedHashSet<>();
 
-    public OrdersModel(Long memberId, Price totalPrice) {
+    public OrdersModel(Long memberId, Price totalPrice, Long couponId) {
         if (memberId == null) {
             throw new CoreException(ErrorType.BAD_REQUEST, "Member ID cannot be null.");
         }
@@ -45,6 +48,7 @@ public class OrdersModel extends BaseEntity {
         this.memberId = memberId;
         this.totalPrice = totalPrice;
         this.status = OrderStatus.NOT_PAID;
+        this.couponId = couponId;
     }
 
     public void addItem(OrderItemModel item) {

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponJpaRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.infrastructure.coupon;
+
+import com.loopers.domain.coupon.CouponModel;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CouponJpaRepository extends JpaRepository<CouponModel, Long> {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponRepositoryImpl.java
@@ -1,0 +1,25 @@
+package com.loopers.infrastructure.coupon;
+
+import com.loopers.domain.coupon.CouponModel;
+import com.loopers.domain.coupon.CouponRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class CouponRepositoryImpl implements CouponRepository {
+
+    private final CouponJpaRepository couponJpaRepository;
+
+    @Override
+    public Optional<CouponModel> find(Long id) {
+        return couponJpaRepository.findById(id);
+    }
+
+    @Override
+    public void saveAndFlush(CouponModel couponModel) {
+        couponJpaRepository.saveAndFlush(couponModel);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/member/MemberJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/member/MemberJpaRepository.java
@@ -1,10 +1,18 @@
 package com.loopers.infrastructure.member;
 
 import com.loopers.domain.member.MemberModel;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface MemberJpaRepository extends JpaRepository<MemberModel, Long> {
     Optional<MemberModel> findByUserId(String userId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select m from MemberModel m where m.id = :id")
+    Optional<MemberModel> findWithLock(@Param("id") Long id);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/member/MemberRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/member/MemberRepositoryImpl.java
@@ -26,4 +26,9 @@ public class MemberRepositoryImpl implements MemberRepository {
     public MemberModel update(MemberModel member) {
         return memberJpaRepository.save(member);
     }
+
+    @Override
+    public Optional<MemberModel> findWithLock(Long id) {
+        return memberJpaRepository.findWithLock(id);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/orders/OrderRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/orders/OrderRepositoryImpl.java
@@ -51,4 +51,14 @@ public class OrderRepositoryImpl implements OrderRepository {
             .fetchOne();
         return Optional.ofNullable(order);
     }
+
+    @Override
+    public List<OrdersModel> searchByCoupon(Long couponId) {
+        return queryFactory
+            .selectFrom(ordersModel)
+            .distinct()
+            .leftJoin(ordersModel.items, orderItemModel).fetchJoin()
+            .where(ordersModel.couponId.eq(couponId))
+            .fetch();
+    }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/application/like/usecase/command/CommandMarkLikeUseCaseTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/like/usecase/command/CommandMarkLikeUseCaseTest.java
@@ -3,6 +3,8 @@ package com.loopers.application.like.usecase.command;
 import com.loopers.application.like.usecase.command.CommandMarkLikeUseCase.Command;
 import com.loopers.application.member.MemberInfo;
 import com.loopers.domain.like.LikeRepository;
+import com.loopers.domain.member.MemberModel;
+import com.loopers.domain.member.MemberRepository;
 import com.loopers.domain.member.enums.Gender;
 import com.loopers.utils.DatabaseCleanUp;
 import org.junit.jupiter.api.AfterEach;
@@ -12,6 +14,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.jdbc.Sql;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -27,6 +30,9 @@ class CommandMarkLikeUseCaseTest {
 
     @Autowired
     private LikeRepository likeRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
 
     @Autowired
     private DatabaseCleanUp databaseCleanUp;
@@ -78,5 +84,58 @@ class CommandMarkLikeUseCaseTest {
 
         assertThat(successCount.get()).isEqualTo(threadCount);
         assertThat(likeCount).isEqualTo(1);
+    }
+
+    @Test
+    @Sql(statements = {
+        "INSERT INTO product (id, name, price, stock, brand_id, like_count, created_at, updated_at, deleted_at) VALUES (1, '테스트상품1', 1000, 15, 1, 0, '2023-10-01 00:00:00', '2023-10-01 00:00:00', NULL)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (1, 'testUser1', 'MALE', 'test@test.com', '2024-01-01', 0, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (2, 'testUser2', 'MALE', 'test@test.com', '2024-01-01', 0, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (3, 'testUser3', 'MALE', 'test@test.com', '2024-01-01', 0, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (4, 'testUser4', 'MALE', 'test@test.com', '2024-01-01', 0, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (5, 'testUser5', 'MALE', 'test@test.com', '2024-01-01', 0, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)"
+    })
+    void 동일한_상품에_대해_여러명이_좋아요를_요청해도_상품의_좋아요_개수가_정상_반영되어야_한다() throws InterruptedException {
+        int threadCount = 5;
+        Long productId = 1L;
+        MemberModel m1 = memberRepository.findByUserId("testUser1").orElseThrow();
+        MemberModel m2 = memberRepository.findByUserId("testUser2").orElseThrow();
+        MemberModel m3 = memberRepository.findByUserId("testUser3").orElseThrow();
+        MemberModel m4 = memberRepository.findByUserId("testUser4").orElseThrow();
+        MemberModel m5 = memberRepository.findByUserId("testUser5").orElseThrow();
+        List<MemberInfo> members = List.of(
+            MemberInfo.from(m1),
+            MemberInfo.from(m2),
+            MemberInfo.from(m3),
+            MemberInfo.from(m4),
+            MemberInfo.from(m5)
+        );
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failureCount = new AtomicInteger();
+
+        for (int i = 0; i < threadCount; i++) {
+            final int idx = i;
+            executor.submit(() -> {
+                try {
+                    commandMarkLikeUseCase.execute(new Command(members.get(idx), productId));
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failureCount.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        long likeCount = likeRepository.getProductLikeCount(productId);
+
+        assertThat(successCount.get()).isEqualTo(threadCount);
+        assertThat(likeCount).isEqualTo(threadCount);
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/application/like/usecase/command/CommandUnmarkLikeUseCaseTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/like/usecase/command/CommandUnmarkLikeUseCaseTest.java
@@ -2,6 +2,8 @@ package com.loopers.application.like.usecase.command;
 
 import com.loopers.application.member.MemberInfo;
 import com.loopers.domain.like.LikeRepository;
+import com.loopers.domain.member.MemberModel;
+import com.loopers.domain.member.MemberRepository;
 import com.loopers.domain.member.enums.Gender;
 import com.loopers.utils.DatabaseCleanUp;
 import org.junit.jupiter.api.AfterEach;
@@ -11,6 +13,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.jdbc.Sql;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -26,6 +29,9 @@ class CommandUnmarkLikeUseCaseTest {
 
     @Autowired
     private LikeRepository likeRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
 
     @Autowired
     private DatabaseCleanUp databaseCleanUp;
@@ -82,5 +88,63 @@ class CommandUnmarkLikeUseCaseTest {
 
         assertThat(successCount.get()).isEqualTo(threadCount);
         assertThat(likeCount).isEqualTo(2);
+    }
+
+    @Test
+    @Sql(statements = {
+        "INSERT INTO product (id, name, price, stock, brand_id, like_count, created_at, updated_at, deleted_at) VALUES (1, '테스트상품1', 1000, 15, 1, 5, '2023-10-01 00:00:00', '2023-10-01 00:00:00', NULL)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (1, 'testUser1', 'MALE', 'test@test.com', '2024-01-01', 0, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (2, 'testUser2', 'MALE', 'test@test.com', '2024-01-01', 0, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (3, 'testUser3', 'MALE', 'test@test.com', '2024-01-01', 0, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (4, 'testUser4', 'MALE', 'test@test.com', '2024-01-01', 0, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (5, 'testUser5', 'MALE', 'test@test.com', '2024-01-01', 0, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)",
+        "insert into likes (created_at, member_id, product_id) values ('2023-10-01 12:00:00', 1, 1)",
+        "insert into likes (created_at, member_id, product_id) values ('2023-10-01 12:00:00', 2, 1)",
+        "insert into likes (created_at, member_id, product_id) values ('2023-10-01 12:00:00', 3, 1)",
+        "insert into likes (created_at, member_id, product_id) values ('2023-10-01 12:00:00', 4, 1)",
+        "insert into likes (created_at, member_id, product_id) values ('2023-10-01 12:00:00', 5, 1)"
+    })
+    void 동일한_상품에_대해_여러명이_좋아요를_취소해도_상품의_좋아요_개수가_정상_반영되어야_한다() throws InterruptedException {
+        int threadCount = 5;
+        Long productId = 1L;
+        MemberModel m1 = memberRepository.findByUserId("testUser1").orElseThrow();
+        MemberModel m2 = memberRepository.findByUserId("testUser2").orElseThrow();
+        MemberModel m3 = memberRepository.findByUserId("testUser3").orElseThrow();
+        MemberModel m4 = memberRepository.findByUserId("testUser4").orElseThrow();
+        MemberModel m5 = memberRepository.findByUserId("testUser5").orElseThrow();
+        List<MemberInfo> members = List.of(
+            MemberInfo.from(m1),
+            MemberInfo.from(m2),
+            MemberInfo.from(m3),
+            MemberInfo.from(m4),
+            MemberInfo.from(m5)
+        );
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failureCount = new AtomicInteger();
+
+        for (int i = 0; i < threadCount; i++) {
+            final int idx = i;
+            executor.submit(() -> {
+                try {
+                    commandUnmarkLikeUseCase.execute(new CommandUnmarkLikeUseCase.Command(members.get(idx), productId));
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failureCount.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        long likeCount = likeRepository.getProductLikeCount(productId);
+
+        assertThat(successCount.get()).isEqualTo(threadCount);
+        assertThat(likeCount).isEqualTo(0);
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/application/orders/usecase/command/CommandOrderUseCaseTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/orders/usecase/command/CommandOrderUseCaseTest.java
@@ -71,7 +71,7 @@ class CommandOrderUseCaseTest {
         for (int i = 0; i < threadCount; i++) {
             executor.submit(() -> {
                 try {
-                    commandOrderUseCase.execute(new CommandOrderUseCase.Command(memberInfo, productIds, quantities));
+                    commandOrderUseCase.execute(new CommandOrderUseCase.Command(memberInfo, productIds, quantities, null));
                     successCount.incrementAndGet();
                 } catch (Exception e) {
                     failureCount.incrementAndGet();
@@ -121,7 +121,7 @@ class CommandOrderUseCaseTest {
             final int memberIndex = i % memberInfos.size();
             executor.submit(() -> {
                 try {
-                    commandOrderUseCase.execute(new CommandOrderUseCase.Command(memberInfos.get(memberIndex), productIds, quantities));
+                    commandOrderUseCase.execute(new CommandOrderUseCase.Command(memberInfos.get(memberIndex), productIds, quantities, null));
                     successCount.incrementAndGet();
                 } catch (Exception e) {
                     failureCount.incrementAndGet();

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponModelTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponModelTest.java
@@ -1,0 +1,141 @@
+package com.loopers.domain.coupon;
+
+import com.loopers.domain.coupon.CouponModel.TargetScope;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class CouponModelTest {
+
+    @Nested
+    class Create {
+
+        static Stream<Arguments> invalidConstructorArgs() {
+            DiscountMethod validDiscount = new DiscountMethod(0.5);
+            TargetScope validScope = TargetScope.ORDER;
+            return Stream.of(
+                Arguments.of(validDiscount, null),
+                Arguments.of(null, validScope),
+                Arguments.of(null, null)
+            );
+        }
+
+        static Stream<Arguments> invalidConstructorArgsWithMemberId() {
+            DiscountMethod validDiscount = new DiscountMethod(0.5);
+            TargetScope validScope = TargetScope.ORDER;
+            Long validMemberId = 1L;
+            return Stream.of(
+                Arguments.of(validDiscount, validScope, null),
+                Arguments.of(null, validScope, validMemberId),
+                Arguments.of(validDiscount, null, validMemberId)
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("invalidConstructorArgs")
+        void throwsIllegalArgumentException_whenRequiredArgsAreNull(DiscountMethod discountMethod, TargetScope targetScope) {
+            assertThrows(IllegalArgumentException.class, () -> {
+                new CouponModel(discountMethod, targetScope);
+            });
+        }
+
+        @ParameterizedTest
+        @MethodSource("invalidConstructorArgsWithMemberId")
+        void throwsIllegalArgumentException_whenRequiredArgsWithMemberIdAreNull(DiscountMethod discountMethod, TargetScope targetScope, Long memberId) {
+            assertThrows(IllegalArgumentException.class, () -> {
+                new CouponModel(discountMethod, targetScope, memberId);
+            });
+        }
+
+        @Test
+        void createCouponModel_whenValidArgsAreProvided() {
+            DiscountMethod discountMethod = new DiscountMethod(0.5);
+            TargetScope targetScope = TargetScope.ORDER;
+
+            CouponModel couponModel = new CouponModel(discountMethod, targetScope);
+
+            assertThat(couponModel.getCode()).isNotNull();
+            assertThat(couponModel.getDiscountMethod()).isEqualTo(discountMethod);
+            assertThat(couponModel.getTargetScope()).isEqualTo(targetScope);
+        }
+
+        @Test
+        void createCouponModel_whenValidArgsWithMemberIdAreProvided() {
+            DiscountMethod discountMethod = new DiscountMethod(0.5);
+            TargetScope targetScope = TargetScope.ORDER;
+            Long memberId = 1L;
+
+            CouponModel couponModel = new CouponModel(discountMethod, targetScope, memberId);
+
+            assertThat(couponModel.getCode()).isNotNull();
+            assertThat(couponModel.getDiscountMethod()).isEqualTo(discountMethod);
+            assertThat(couponModel.getTargetScope()).isEqualTo(targetScope);
+            assertThat(couponModel.getMemberId()).isEqualTo(memberId);
+            assertThat(couponModel.getIssuedAt()).isNotNull();
+        }
+    }
+
+    @Nested
+    class IssueTo {
+
+        @Test
+        void issueTo_whenAlreadyIssued_throwsIllegalStateException() {
+            DiscountMethod discountMethod = new DiscountMethod(0.5);
+            TargetScope targetScope = TargetScope.ORDER;
+            Long memberId = 1L;
+            CouponModel couponModel = new CouponModel(discountMethod, targetScope, memberId);
+
+            assertThrows(IllegalStateException.class, () -> {
+                couponModel.issueTo(memberId);
+            });
+        }
+
+        @Test
+        void issueTo_whenNotIssued_setsMemberIdAndIssuedAt() {
+            DiscountMethod discountMethod = new DiscountMethod(0.5);
+            TargetScope targetScope = TargetScope.ORDER;
+            Long memberId = 1L;
+
+            CouponModel couponModel = new CouponModel(discountMethod, targetScope);
+
+            couponModel.issueTo(memberId);
+
+            assertThat(couponModel.getMemberId()).isEqualTo(memberId);
+            assertThat(couponModel.getIssuedAt()).isNotNull();
+        }
+    }
+
+    @Nested
+    class Apply {
+        @Test
+        void apply_whenDiscountMethodIsNull_throwsIllegalStateException() throws Exception {
+            CouponModel couponModel = new CouponModel(new DiscountMethod(0.5), TargetScope.ORDER);
+
+            ReflectionTestUtils.setField(couponModel, "discountMethod", null);
+
+            assertThrows(IllegalStateException.class, () -> {
+                couponModel.apply(BigDecimal.valueOf(100));
+            });
+        }
+
+        @Test
+        void apply_whenValidDiscountMethod_appliesDiscount() {
+            DiscountMethod discountMethod = new DiscountMethod(BigDecimal.valueOf(20));
+            CouponModel couponModel = new CouponModel(discountMethod, TargetScope.ORDER);
+
+            BigDecimal originalPrice = BigDecimal.valueOf(100);
+            BigDecimal discountedPrice = couponModel.apply(originalPrice);
+
+            assertThat(discountedPrice).isEqualTo(BigDecimal.valueOf(80));
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponModelTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponModelTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.math.BigDecimal;
+import java.time.ZonedDateTime;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -136,6 +137,58 @@ class CouponModelTest {
             BigDecimal discountedPrice = couponModel.apply(originalPrice);
 
             assertThat(discountedPrice).isEqualTo(BigDecimal.valueOf(80));
+        }
+
+        @Test
+        void apply_whenDeletedAtIsNotNull_throwsIllegalStateException() {
+            DiscountMethod discountMethod = new DiscountMethod(0.5);
+            CouponModel couponModel = new CouponModel(discountMethod, TargetScope.ORDER);
+            ReflectionTestUtils.setField(couponModel, "deletedAt", ZonedDateTime.now());
+
+            assertThrows(IllegalStateException.class, () -> {
+                couponModel.apply(BigDecimal.valueOf(100));
+            });
+        }
+
+        @Test
+        void apply_whenApplied_deletesCoupon() {
+            DiscountMethod discountMethod = new DiscountMethod(0.5);
+            CouponModel couponModel = new CouponModel(discountMethod, TargetScope.ORDER);
+
+            BigDecimal originalPrice = BigDecimal.valueOf(100);
+            couponModel.apply(originalPrice);
+
+            assertThat(couponModel.getDeletedAt()).isNotNull();
+        }
+    }
+
+    @Nested
+    class HasOwned {
+
+        @Test
+        void hasOwned_whenGivenMemberIdIsNull_returnsFalse() {
+            CouponModel couponModel = new CouponModel(new DiscountMethod(0.5), TargetScope.ORDER);
+            assertThat(couponModel.hasOwned(null)).isFalse();
+        }
+
+        @Test
+        void hasOwned_whenCouponMemberIdIsNull_returnsFalse() {
+            CouponModel couponModel = new CouponModel(new DiscountMethod(0.5), TargetScope.ORDER);
+            assertThat(couponModel.hasOwned(1L)).isFalse();
+        }
+
+        @Test
+        void hasOwned_whenMemberIdMatches_returnsTrue() {
+            Long memberId = 1L;
+            CouponModel couponModel = new CouponModel(new DiscountMethod(0.5), TargetScope.ORDER, memberId);
+            assertThat(couponModel.hasOwned(memberId)).isTrue();
+        }
+
+        @Test
+        void hasOwned_whenMemberIdDoesNotMatch_returnsFalse() {
+            Long memberId = 1L;
+            CouponModel couponModel = new CouponModel(new DiscountMethod(0.5), TargetScope.ORDER, memberId);
+            assertThat(couponModel.hasOwned(2L)).isFalse();
         }
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/DiscountMethodTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/DiscountMethodTest.java
@@ -1,0 +1,109 @@
+package com.loopers.domain.coupon;
+
+import com.loopers.domain.coupon.DiscountMethod.DiscountType;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class DiscountMethodTest {
+
+    @Nested
+    class Create {
+
+        @Test
+        void throwsException_WhenAmountIsNull() {
+            assertThrows(
+                IllegalArgumentException.class,
+                () -> new DiscountMethod((BigDecimal) null)
+            );
+        }
+
+        @Test
+        void throwsException_WhenRateIsNull() {
+            assertThrows(
+                IllegalArgumentException.class,
+                () -> new DiscountMethod((Double) null)
+            );
+        }
+
+        @Test
+        void create_WithFixedAmount() {
+            DiscountMethod discountMethod = new DiscountMethod(BigDecimal.valueOf(1000));
+
+            assertEquals(DiscountType.FIXED_AMOUNT, discountMethod.getDiscountType());
+            assertEquals(BigDecimal.valueOf(1000), discountMethod.getAmount());
+            assertNull(discountMethod.getRate());
+        }
+
+        @Test
+        void create_WithRate() {
+            DiscountMethod discountMethod = new DiscountMethod(0.1);
+
+            assertEquals(DiscountType.RATE, discountMethod.getDiscountType());
+            assertEquals(0.1, discountMethod.getRate());
+            assertNull(discountMethod.getAmount());
+        }
+    }
+
+    @Nested
+    class ToPolicy {
+        @Test
+        void toPolicy_withFixedAmount_returnsFixedAmountPolicy() {
+            // Given
+            DiscountMethod discountMethod = new DiscountMethod(BigDecimal.valueOf(1000));
+
+            // When
+            DiscountPolicy policy = discountMethod.toPolicy();
+
+            // Then
+            assertThat(policy).isInstanceOf(FixedAmountPolicy.class);
+        }
+
+        @Test
+        void toPolicy_withRate_returnsRatePolicy() {
+            // Given
+            DiscountMethod discountMethod = new DiscountMethod(0.1);
+
+            // When
+            DiscountPolicy policy = discountMethod.toPolicy();
+
+            // Then
+            assertThat(policy).isInstanceOf(RatePolicy.class);
+        }
+
+        @Test
+        void toPolicy_withFixedAmountTypeAndNullAmount_throwsException() {
+            // Given
+            DiscountMethod discountMethod = new DiscountMethod(BigDecimal.valueOf(1000));
+            ReflectionTestUtils.setField(discountMethod, "amount", null);
+
+            // When & Then
+            assertThrows(IllegalArgumentException.class, discountMethod::toPolicy);
+        }
+
+        @Test
+        void toPolicy_withRateTypeAndNullRate_throwsException() {
+            // Given
+            DiscountMethod discountMethod = new DiscountMethod(0.5);
+            ReflectionTestUtils.setField(discountMethod, "rate", null);
+
+            // When & Then
+            assertThrows(IllegalArgumentException.class, discountMethod::toPolicy);
+        }
+
+        @Test
+        void toPolicy_withUnknownType_throwsException() {
+            // Given
+            DiscountMethod discountMethod = new DiscountMethod(BigDecimal.TEN); // 정상 객체 생성
+            ReflectionTestUtils.setField(discountMethod, "discountType", null);
+
+            // When & Then
+            assertThrows(IllegalStateException.class, discountMethod::toPolicy);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/FixedAmountPolicyTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/FixedAmountPolicyTest.java
@@ -1,0 +1,56 @@
+package com.loopers.domain.coupon;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class FixedAmountPolicyTest {
+
+    @Nested
+    class Create {
+
+        @Test
+        void throwsException_whenAmountIsNegative() {
+            assertThrows(
+                IllegalArgumentException.class,
+                () -> new FixedAmountPolicy(BigDecimal.valueOf(-100))
+            );
+        }
+
+        @Test
+        void create_withValidAmount() {
+            FixedAmountPolicy policy = new FixedAmountPolicy(BigDecimal.valueOf(1000));
+
+            assertEquals(BigDecimal.valueOf(1000), policy.amount());
+        }
+    }
+
+    @Nested
+    class ApplyDiscount {
+
+        @Test
+        void applyDiscount_returnsZero_whenOriginalPriceIsLessThanAmount() {
+            FixedAmountPolicy policy = new FixedAmountPolicy(BigDecimal.valueOf(1000));
+            BigDecimal originalPrice = BigDecimal.valueOf(500);
+
+            BigDecimal discountedPrice = policy.applyDiscount(originalPrice);
+
+            assertEquals(BigDecimal.ZERO, discountedPrice);
+        }
+
+        @Test
+        void applyDiscount_returnsCorrectValue_whenOriginalPriceIsGreaterThanAmount() {
+            FixedAmountPolicy policy = new FixedAmountPolicy(BigDecimal.valueOf(500));
+            BigDecimal originalPrice = BigDecimal.valueOf(2000);
+
+            BigDecimal discountedPrice = policy.applyDiscount(originalPrice);
+
+            assertEquals(BigDecimal.valueOf(1500), discountedPrice);
+        }
+
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/RatePolicyTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/RatePolicyTest.java
@@ -1,0 +1,74 @@
+package com.loopers.domain.coupon;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class RatePolicyTest {
+
+    @Nested
+    class Create {
+
+        @Test
+        void throwsException_whenRateIsNegative() {
+            assertThrows(
+                IllegalArgumentException.class,
+                () -> new RatePolicy(-0.1)
+            );
+        }
+
+        @Test
+        void throwsException_whenRateIsOverOne() {
+            assertThrows(
+                IllegalArgumentException.class,
+                () -> new RatePolicy(1.1)
+            );
+        }
+
+        @Test
+        void create_withValidRate() {
+            RatePolicy policy = new RatePolicy(0.2);
+
+            assertEquals(0.2, policy.rate());
+        }
+    }
+
+    @Nested
+    class ApplyDiscount {
+
+        @Test
+        void throwsException_whenOriginalPriceIsNegative() {
+            RatePolicy policy = new RatePolicy(0.2);
+            BigDecimal originalPrice = BigDecimal.valueOf(-100);
+
+            assertThrows(
+                IllegalArgumentException.class,
+                () -> policy.applyDiscount(originalPrice)
+            );
+        }
+
+        @Test
+        void applyDiscount_returnsZero_whenOriginalPriceIsZero() {
+            RatePolicy policy = new RatePolicy(0.2);
+            BigDecimal originalPrice = BigDecimal.ZERO;
+
+            BigDecimal discountedPrice = policy.applyDiscount(originalPrice);
+
+            assertEquals(BigDecimal.ZERO, discountedPrice);
+        }
+
+        @Test
+        void applyDiscount_returnsCorrectValue_whenOriginalPriceIsPositive() {
+            RatePolicy policy = new RatePolicy(0.2);
+            BigDecimal originalPrice = BigDecimal.valueOf(1000);
+
+            BigDecimal discountedPrice = policy.applyDiscount(originalPrice);
+
+            assertEquals(BigDecimal.valueOf(800), discountedPrice);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/orders/OrderServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/orders/OrderServiceTest.java
@@ -54,7 +54,7 @@ class OrderServiceTest {
 
             when(orderRepository.save(any(OrdersModel.class))).thenReturn(order);
 
-            OrdersModel result = orderService.order(member, products);
+            OrdersModel result = orderService.order(member, products, null);
 
             assertThat(result).isNotNull();
             verify(orderRepository).save(any(OrdersModel.class));
@@ -65,7 +65,7 @@ class OrderServiceTest {
         @DisplayName("member가 null이면 BAD_REQUEST 예외 발생")
         void order_memberNull_throwsException() {
             List<Pair<ProductModel, Long>> products = List.of();
-            CoreException ex = assertThrows(CoreException.class, () -> orderService.order(null, products));
+            CoreException ex = assertThrows(CoreException.class, () -> orderService.order(null, products, null));
             assertThat(ex.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
         }
 
@@ -73,7 +73,7 @@ class OrderServiceTest {
         @DisplayName("products가 null이면 BAD_REQUEST 예외 발생")
         void order_productsNull_throwsException() {
             MemberModel member = new MemberModel("user1", Gender.FEMALE, "2000-01-01", "test@test.com", 1000L);
-            CoreException ex = assertThrows(CoreException.class, () -> orderService.order(member, null));
+            CoreException ex = assertThrows(CoreException.class, () -> orderService.order(member, null, null));
             assertThat(ex.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
         }
 
@@ -81,7 +81,7 @@ class OrderServiceTest {
         @DisplayName("products가 비어있으면 BAD_REQUEST 예외 발생")
         void order_productsEmpty_throwsException() {
             MemberModel member = new MemberModel("user1", Gender.FEMALE, "2000-01-01", "test@test.com", 1000L);
-            CoreException ex = assertThrows(CoreException.class, () -> orderService.order(member, Collections.emptyList()));
+            CoreException ex = assertThrows(CoreException.class, () -> orderService.order(member, Collections.emptyList(), null));
             assertThat(ex.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
         }
 
@@ -93,7 +93,7 @@ class OrderServiceTest {
             ProductModel product = new ProductModel("p1", com.loopers.domain.product.vo.Price.ZERO, Stock.of(1568), 369L);
             ReflectionTestUtils.setField(product, "id", 123L);
             List<Pair<ProductModel, Long>> products = List.of(Pair.of(product, 0L));
-            CoreException ex = assertThrows(CoreException.class, () -> orderService.order(member, products));
+            CoreException ex = assertThrows(CoreException.class, () -> orderService.order(member, products, null));
             assertThat(ex.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
         }
     }


### PR DESCRIPTION
## 📌 Summary

- 쿠폰 도메인 추가
- 주문 시 쿠폰 적용 기능 구현
- 테스트 케이스 보충

## ✅ Checklist

### 🗞️ Coupon 도메인

- [x]  쿠폰은 사용자가 소유하고 있으며, 이미 사용된 쿠폰은 사용할 수 없어야 한다.
- [x]  쿠폰 종류는 정액 / 정률로 구분되며, 각 적용 로직을 구현하였다.
- [x]  각 발급된 쿠폰은 최대 한번만 사용될 수 있다.

### 🧾 **주문**

- [x]  주문 전체 흐름에 대해 원자성이 보장되어야 한다.
- [x]  사용 불가능하거나 존재하지 않는 쿠폰일 경우 주문은 실패해야 한다.
- [x]  재고가 존재하지 않거나 부족할 경우 주문은 실패해야 한다.
- [x]  주문 시 유저의 포인트 잔액이 부족할 경우 주문은 실패해야 한다
- [x]  쿠폰, 재고, 포인트 처리 등 하나라도 작업이 실패하면 모두 롤백처리되어야 한다.
- [x]  주문 성공 시, 모든 처리는 정상 반영되어야 한다.

### 🧪 동시성 테스트

- [x]  동일한 상품에 대해 여러명이 좋아요/싫어요를 요청해도, 상품의 좋아요 개수가 정상 반영되어야 한다.
- [x]  동일한 쿠폰으로 여러 기기에서 동시에 주문해도, 쿠폰은 단 한번만 사용되어야 한다.