### PR TITLE
[round-4] Transactional Operation

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/like/usecase/command/CommandMarkLikeUseCase.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/usecase/command/CommandMarkLikeUseCase.java
@@ -32,7 +32,7 @@ public class CommandMarkLikeUseCase {
 
         try {
             likeService.like(member, product);
-        } catch (DataIntegrityViolationException _) {
+        } catch (DataIntegrityViolationException e) {
         }
 
         productService.updateProductLikeCount(product, likeService.getLikeCount(product));

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/usecase/command/CommandMarkLikeUseCase.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/usecase/command/CommandMarkLikeUseCase.java
@@ -22,7 +22,7 @@ public class CommandMarkLikeUseCase {
     private final LikeService likeService;
 
     @Transactional
-    void execute(Command command) {
+    public void execute(Command command) {
         if (command == null) {
             throw new CoreException(ErrorType.BAD_REQUEST, "Command cannot be null");
         }

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/usecase/command/CommandMarkLikeUseCase.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/usecase/command/CommandMarkLikeUseCase.java
@@ -9,6 +9,7 @@ import com.loopers.domain.product.ProductService;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,7 +30,10 @@ public class CommandMarkLikeUseCase {
         MemberModel member = memberService.getMember(command.memberInfo.userId());
         ProductModel product = productService.getDetail(command.productId());
 
-        likeService.like(member, product);
+        try {
+            likeService.like(member, product);
+        } catch (DataIntegrityViolationException _) {
+        }
 
         productService.updateProductLikeCount(product, likeService.getLikeCount(product));
     }

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/usecase/command/CommandUnmarkLikeUseCase.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/usecase/command/CommandUnmarkLikeUseCase.java
@@ -21,7 +21,7 @@ public class CommandUnmarkLikeUseCase {
     private final LikeService likeService;
 
     @Transactional
-    void execute(Command command) {
+    public void execute(Command command) {
         if (command == null) {
             throw new CoreException(ErrorType.BAD_REQUEST, "Command cannot be null");
         }

--- a/apps/commerce-api/src/main/java/com/loopers/application/orders/dto/OrderInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/orders/dto/OrderInfo.java
@@ -7,16 +7,17 @@ import com.loopers.support.error.ErrorType;
 import java.math.BigDecimal;
 import java.util.List;
 
-public record OrderInfo(Long memberId, BigDecimal totalPrice, String status, List<OrderItemInfo> items) {
+public record OrderInfo(Long id, Long memberId, BigDecimal totalPrice, String status, List<OrderItemInfo> items) {
 
     public OrderInfo {
-        if (memberId == null || totalPrice == null || status == null || status.isBlank() || items == null || items.isEmpty()) {
+        if (id == null || memberId == null || totalPrice == null || status == null || status.isBlank() || items == null || items.isEmpty()) {
             throw new CoreException(ErrorType.BAD_REQUEST, "All fields must be provided and items cannot be empty");
         }
     }
 
     public static OrderInfo from(OrdersModel order) {
         return new OrderInfo(
+            order.getId(),
             order.getMemberId(),
             order.getTotalPrice().getAmount(),
             order.getStatus().name(),

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponModel.java
@@ -1,0 +1,128 @@
+package com.loopers.domain.coupon;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "coupon")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CouponModel {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Getter
+    private final Long id = 0L;
+
+    @Getter
+    @Version
+    private Long version;
+
+    @Column(unique = true, nullable = false, updatable = false)
+    @Getter
+    private String code;
+
+    @Embedded
+    @Getter
+    private DiscountMethod discountMethod;
+
+    @Column(name = "member_id")
+    @Getter
+    private Long memberId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "target_scope", nullable = false)
+    @Getter
+    private TargetScope targetScope;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private ZonedDateTime createdAt;
+
+    @Column(name = "issued_at")
+    @Getter
+    private ZonedDateTime issuedAt;
+
+    @Column(name = "deleted_at")
+    @Getter
+    private ZonedDateTime deletedAt;
+
+    public CouponModel(DiscountMethod discountMethod, TargetScope targetScope) {
+        if (discountMethod == null || targetScope == null) {
+            throw new IllegalArgumentException("할인 방법과 대상 범위는 null 일 수 없습니다.");
+        }
+        this.code = UUID.randomUUID().toString();
+        this.discountMethod = discountMethod;
+        this.targetScope = targetScope;
+        this.version = 0L;
+    }
+
+    public CouponModel(DiscountMethod discountMethod, TargetScope targetScope, Long memberId) {
+        if (discountMethod == null || targetScope == null || memberId == null) {
+            throw new IllegalArgumentException("할인 방법, 대상 범위, 회원 아이디는 null 일 수 없습니다.");
+        }
+        this.code = UUID.randomUUID().toString();
+        this.discountMethod = discountMethod;
+        this.targetScope = targetScope;
+        this.memberId = memberId;
+        this.issuedAt = ZonedDateTime.now();
+        this.version = 0L;
+    }
+
+    public void issueTo(Long memberId) {
+        if (this.issuedAt != null) {
+            throw new IllegalStateException("이미 발급된 쿠폰입니다.");
+        }
+        this.memberId = memberId;
+        this.issuedAt = ZonedDateTime.now();
+    }
+
+    public BigDecimal apply(BigDecimal originalPrice) {
+        if (this.discountMethod == null) {
+            throw new IllegalStateException("할인 규칙이 설정되지 않았습니다.");
+        }
+        if (this.deletedAt != null) {
+            throw new IllegalStateException("사용된 쿠폰입니다. 사용할 수 없습니다.");
+        }
+        delete();
+        return this.discountMethod.toPolicy().applyDiscount(originalPrice);
+    }
+
+    public boolean hasOwned(Long memberId) {
+        if (memberId == null || this.memberId == null) {
+            return false;
+        }
+        return this.memberId.equals(memberId);
+    }
+
+    @PrePersist
+    private void prePersist() {
+        this.createdAt = ZonedDateTime.now();
+    }
+
+    /**
+     * delete 연산은 멱등하게 동작할 수 있도록 한다. (삭제된 엔티티를 다시 삭제해도 동일한 결과가 나오도록)
+     */
+    public void delete() {
+        if (this.deletedAt == null) {
+            this.deletedAt = ZonedDateTime.now();
+        }
+    }
+
+    /**
+     * restore 연산은 멱등하게 동작할 수 있도록 한다. (삭제되지 않은 엔티티를 복원해도 동일한 결과가 나오도록)
+     */
+    public void restore() {
+        if (this.deletedAt != null) {
+            this.deletedAt = null;
+        }
+    }
+
+    public enum TargetScope {
+        ORDER
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponRepository.java
@@ -1,0 +1,9 @@
+package com.loopers.domain.coupon;
+
+import java.util.Optional;
+
+public interface CouponRepository {
+    Optional<CouponModel> find(Long id);
+
+    void saveAndFlush(CouponModel couponModel);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/DiscountMethod.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/DiscountMethod.java
@@ -1,0 +1,72 @@
+package com.loopers.domain.coupon;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DiscountMethod {
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "discount_type", nullable = false)
+    @Getter
+    private DiscountType discountType;
+
+    @Getter
+    private BigDecimal amount;
+
+    @Getter
+    private Double rate;
+
+    public DiscountMethod(BigDecimal amount) {
+        if (amount == null) {
+            throw new IllegalArgumentException("할인 금액은 null 일 수 없습니다.");
+        }
+
+        this.discountType = DiscountType.FIXED_AMOUNT;
+        this.amount = amount;
+    }
+
+    public DiscountMethod(Double rate) {
+        if (rate == null) {
+            throw new IllegalArgumentException("할인율은 null 일 수 없습니다.");
+        }
+
+        this.discountType = DiscountType.RATE;
+        this.rate = rate;
+    }
+
+    public DiscountPolicy toPolicy() {
+        if (discountType == null) {
+            throw new IllegalStateException("할인 유형이 설정되지 않았습니다.");
+        }
+        
+        switch (discountType) {
+            case FIXED_AMOUNT -> {
+                if (amount == null) {
+                    throw new IllegalArgumentException("할인 금액은 null 일 수 없습니다.");
+                }
+                return new FixedAmountPolicy(amount);
+            }
+            case RATE -> {
+                if (rate == null) {
+                    throw new IllegalArgumentException("할인율은 null 일 수 없습니다.");
+                }
+                return new RatePolicy(rate);
+            }
+            default -> throw new IllegalStateException("알 수 없는 할인 유형: " + discountType);
+        }
+    }
+
+    public enum DiscountType {
+        FIXED_AMOUNT, // 정액 할인
+        RATE // 정률 할인
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/DiscountPolicy.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/DiscountPolicy.java
@@ -1,0 +1,7 @@
+package com.loopers.domain.coupon;
+
+import java.math.BigDecimal;
+
+public interface DiscountPolicy {
+    BigDecimal applyDiscount(BigDecimal originalPrice);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/FixedAmountPolicy.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/FixedAmountPolicy.java
@@ -1,0 +1,20 @@
+package com.loopers.domain.coupon;
+
+import java.math.BigDecimal;
+
+public record FixedAmountPolicy(BigDecimal amount) implements DiscountPolicy {
+
+    public FixedAmountPolicy {
+        if (amount.compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException("고정 금액 할인 정책의 금액은 음수일 수 없습니다.");
+        }
+    }
+
+    @Override
+    public BigDecimal applyDiscount(BigDecimal originalPrice) {
+        if (originalPrice.compareTo(amount) < 0) {
+            return BigDecimal.ZERO;
+        }
+        return originalPrice.subtract(amount);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/RatePolicy.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/RatePolicy.java
@@ -1,0 +1,22 @@
+package com.loopers.domain.coupon;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+public record RatePolicy(double rate) implements DiscountPolicy {
+
+    public RatePolicy {
+        if (rate < 0 || rate > 1) {
+            throw new IllegalArgumentException("할인율은 0과 1 사이의 값이어야 합니다.");
+        }
+    }
+
+    @Override
+    public BigDecimal applyDiscount(BigDecimal originalPrice) {
+        if (originalPrice.compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException("원래 가격은 음수일 수 없습니다.");
+        }
+        BigDecimal discountAmount = originalPrice.multiply(BigDecimal.valueOf(rate));
+        return originalPrice.subtract(discountAmount).setScale(0, RoundingMode.CEILING);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeRepository.java
@@ -18,4 +18,6 @@ public interface LikeRepository {
     List<LikeModel> search(MemberModel member, Pageable pageable);
 
     long countMemberLikedProducts(Long memberId);
+
+    Optional<LikeModel> findWithLock(Long memberId, Long productId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
@@ -7,6 +7,8 @@ import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -17,12 +19,14 @@ public class LikeService {
 
     private final LikeRepository likeRepository;
 
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void like(MemberModel member, ProductModel product) {
         if (member == null || product == null) {
             throw new CoreException(ErrorType.BAD_REQUEST, "Member and Product cannot be null");
         }
 
         Optional<LikeModel> like = likeRepository.find(member.getId(), product.getId());
+
         if (like.isEmpty()) {
             likeRepository.save(new LikeModel(member.getId(), product.getId()));
         }
@@ -33,7 +37,7 @@ public class LikeService {
             throw new CoreException(ErrorType.BAD_REQUEST, "Member and Product cannot be null");
         }
 
-        Optional<LikeModel> like = likeRepository.find(member.getId(), product.getId());
+        Optional<LikeModel> like = likeRepository.findWithLock(member.getId(), product.getId());
         like.ifPresent(likeRepository::delete);
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/member/MemberModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/member/MemberModel.java
@@ -4,10 +4,8 @@ import com.loopers.domain.BaseEntity;
 import com.loopers.domain.member.enums.Gender;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
+import lombok.Getter;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
@@ -16,16 +14,25 @@ import java.time.format.DateTimeParseException;
 @Table(name = "member")
 public class MemberModel extends BaseEntity {
 
+    @Getter
     private String userId;
 
     @Enumerated(EnumType.STRING)
+    @Getter
     private Gender gender;
 
+    @Getter
     private LocalDate birthdate;
 
+    @Getter
     private String email;
 
+    @Getter
     private Long points;
+
+    @Getter
+    @Version
+    private Long version;
 
     protected MemberModel() {
     }
@@ -68,26 +75,7 @@ public class MemberModel extends BaseEntity {
         this.birthdate = parsedBirthdate;
         this.email = email;
         this.points = points;
-    }
-
-    public String getUserId() {
-        return userId;
-    }
-
-    public Gender getGender() {
-        return gender;
-    }
-
-    public LocalDate getBirthdate() {
-        return birthdate;
-    }
-
-    public String getEmail() {
-        return email;
-    }
-
-    public Long getPoints() {
-        return points;
+        this.version = null;
     }
 
     public Long chargePoints(Long amount) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/member/MemberRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/member/MemberRepository.java
@@ -8,4 +8,6 @@ public interface MemberRepository {
     MemberModel create(MemberModel member);
 
     MemberModel update(MemberModel member);
+
+    Optional<MemberModel> findWithLock(Long id);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/orders/OrderRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/orders/OrderRepository.java
@@ -12,4 +12,6 @@ public interface OrderRepository {
     List<OrdersModel> search(Long memberId);
 
     Optional<OrdersModel> find(Long orderId);
+
+    List<OrdersModel> searchByCoupon(Long couponId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/orders/OrderService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/orders/OrderService.java
@@ -29,6 +29,7 @@ public class OrderService {
             .reduce(BigDecimal.ZERO, BigDecimal::add));
 
         OrdersModel order = new OrdersModel(member.getId(), totalPrice);
+        OrdersModel savedOrder = orderRepository.save(order);
 
         for (Pair<ProductModel, Long> pair : products) {
             ProductModel product = pair.getFirst();
@@ -39,15 +40,14 @@ public class OrderService {
             }
 
             OrderItemModel item = new OrderItemModel(
-                order,
+                savedOrder,
                 ProductSnapshot.of(product.getId(), product.getName(), Price.of(product.getPrice().getAmount())),
                 quantity
             );
-            order.addItem(item);
+            savedOrder.addItem(item);
         }
 
-        OrdersModel savedOrder = orderRepository.save(order);
-        orderRepository.saveAll(order.getItems());
+        orderRepository.saveAll(savedOrder.getItems());
         return savedOrder;
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/orders/OrderService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/orders/OrderService.java
@@ -19,7 +19,7 @@ public class OrderService {
 
     private final OrderRepository orderRepository;
 
-    public OrdersModel order(MemberModel member, List<Pair<ProductModel, Long>> products) {
+    public OrdersModel order(MemberModel member, List<Pair<ProductModel, Long>> products, Long couponId) {
         if (member == null || products == null || products.isEmpty()) {
             throw new CoreException(ErrorType.BAD_REQUEST, "Member and Products cannot be null or empty.");
         }
@@ -28,14 +28,14 @@ public class OrderService {
             .map(pair -> pair.getFirst().getPrice().multiply(pair.getSecond()).getAmount())
             .reduce(BigDecimal.ZERO, BigDecimal::add));
 
-        OrdersModel order = new OrdersModel(member.getId(), totalPrice);
+        OrdersModel order = new OrdersModel(member.getId(), totalPrice, couponId);
         OrdersModel savedOrder = orderRepository.save(order);
 
         for (Pair<ProductModel, Long> pair : products) {
             ProductModel product = pair.getFirst();
             Long quantity = pair.getSecond();
 
-            if (product == null || quantity == null || quantity <= 0) {
+            if (quantity <= 0) {
                 throw new CoreException(ErrorType.BAD_REQUEST, "Product and quantity must be valid.");
             }
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/orders/OrderService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/orders/OrderService.java
@@ -47,7 +47,6 @@ public class OrderService {
             savedOrder.addItem(item);
         }
 
-        orderRepository.saveAll(savedOrder.getItems());
         return savedOrder;
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/orders/OrdersModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/orders/OrdersModel.java
@@ -21,6 +21,9 @@ public class OrdersModel extends BaseEntity {
     @Getter
     private Long memberId;
 
+    @Getter
+    private Long couponId;
+
     @Embedded
     @AttributeOverride(name = "amount", column = @Column(name = "total_price"))
     @Getter
@@ -35,6 +38,10 @@ public class OrdersModel extends BaseEntity {
     private Set<OrderItemModel> items = new LinkedHashSet<>();
 
     public OrdersModel(Long memberId, Price totalPrice) {
+        this(memberId, totalPrice, null);
+    }
+
+    public OrdersModel(Long memberId, Price totalPrice, Long couponId) {
         if (memberId == null) {
             throw new CoreException(ErrorType.BAD_REQUEST, "Member ID cannot be null.");
         }
@@ -45,6 +52,7 @@ public class OrdersModel extends BaseEntity {
         this.memberId = memberId;
         this.totalPrice = totalPrice;
         this.status = OrderStatus.NOT_PAID;
+        this.couponId = couponId;
     }
 
     public void addItem(OrderItemModel item) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/orders/OrdersModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/orders/OrdersModel.java
@@ -33,7 +33,7 @@ public class OrdersModel extends BaseEntity {
     @Getter
     private OrderStatus status;
 
-    @OneToMany(mappedBy = "orders", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "orders", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @Getter
     private Set<OrderItemModel> items = new LinkedHashSet<>();
 
@@ -58,5 +58,12 @@ public class OrdersModel extends BaseEntity {
     public void addItem(OrderItemModel item) {
         items.add(item);
         item.setOrders(this);
+    }
+
+    public void process() {
+        if (this.status != OrderStatus.NOT_PAID) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "Order is already processed.");
+        }
+        this.status = OrderStatus.PAID;
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
@@ -17,4 +17,6 @@ public interface ProductRepository {
     Optional<ProductModel> find(Long productId);
 
     ProductModel save(ProductModel product);
+
+    Optional<ProductModel> findWithLock(Long productId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponJpaRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.infrastructure.coupon;
+
+import com.loopers.domain.coupon.CouponModel;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CouponJpaRepository extends JpaRepository<CouponModel, Long> {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponRepositoryImpl.java
@@ -1,0 +1,25 @@
+package com.loopers.infrastructure.coupon;
+
+import com.loopers.domain.coupon.CouponModel;
+import com.loopers.domain.coupon.CouponRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class CouponRepositoryImpl implements CouponRepository {
+
+    private final CouponJpaRepository couponJpaRepository;
+
+    @Override
+    public Optional<CouponModel> find(Long id) {
+        return couponJpaRepository.findById(id);
+    }
+
+    @Override
+    public void saveAndFlush(CouponModel couponModel) {
+        couponJpaRepository.saveAndFlush(couponModel);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.loopers.domain.like.LikeModel;
 import com.loopers.domain.like.LikeRepository;
 import com.loopers.domain.member.MemberModel;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.LockModeType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
@@ -65,5 +66,15 @@ public class LikeRepositoryImpl implements LikeRepository {
             .where(likeModel.memberId.eq(memberId))
             .fetchOne();
         return count != null ? count : 0L;
+    }
+
+    @Override
+    public Optional<LikeModel> findWithLock(Long memberId, Long productId) {
+        return Optional.ofNullable(
+            queryFactory.selectFrom(likeModel)
+                .where(likeModel.memberId.eq(memberId).and(likeModel.productId.eq(productId)))
+                .setLockMode(LockModeType.PESSIMISTIC_WRITE)
+                .fetchOne()
+        );
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/member/MemberJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/member/MemberJpaRepository.java
@@ -1,10 +1,18 @@
 package com.loopers.infrastructure.member;
 
 import com.loopers.domain.member.MemberModel;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface MemberJpaRepository extends JpaRepository<MemberModel, Long> {
     Optional<MemberModel> findByUserId(String userId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select m from MemberModel m where m.id = :id")
+    Optional<MemberModel> findWithLock(@Param("id") Long id);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/member/MemberRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/member/MemberRepositoryImpl.java
@@ -26,4 +26,9 @@ public class MemberRepositoryImpl implements MemberRepository {
     public MemberModel update(MemberModel member) {
         return memberJpaRepository.save(member);
     }
+
+    @Override
+    public Optional<MemberModel> findWithLock(Long id) {
+        return memberJpaRepository.findWithLock(id);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/orders/OrderRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/orders/OrderRepositoryImpl.java
@@ -51,4 +51,14 @@ public class OrderRepositoryImpl implements OrderRepository {
             .fetchOne();
         return Optional.ofNullable(order);
     }
+
+    @Override
+    public List<OrdersModel> searchByCoupon(Long couponId) {
+        return queryFactory
+            .selectFrom(ordersModel)
+            .distinct()
+            .leftJoin(ordersModel.items, orderItemModel).fetchJoin()
+            .where(ordersModel.couponId.eq(couponId))
+            .fetch();
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
@@ -10,6 +10,7 @@ import com.loopers.support.error.ErrorType;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.LockModeType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort.Direction;
@@ -103,5 +104,14 @@ public class ProductRepositoryImpl implements ProductRepository {
             case LIKES -> direction.isAscending() ? productModel.likeCount.asc() : productModel.likeCount.desc();
             case PRICE -> direction.isAscending() ? productModel.price.amount.asc() : productModel.price.amount.desc();
         };
+    }
+
+    @Override
+    public Optional<ProductModel> findWithLock(Long productId) {
+        return Optional.ofNullable(queryFactory.selectFrom(productModel)
+            .where(productModel.id.eq(productId))
+            .setLockMode(LockModeType.PESSIMISTIC_WRITE)
+            .fetchOne()
+        );
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/brand/BrandV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/brand/BrandV1ApiSpec.java
@@ -1,0 +1,18 @@
+package com.loopers.interfaces.api.brand;
+
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Brand V1 API", description = "브랜드 API 입니다")
+public interface BrandV1ApiSpec {
+
+    @Operation(
+        summary = "브랜드 정보 조회"
+    )
+    ApiResponse<BrandV1Dto.BrandResponse> getBrand(
+        @Schema(name = "브랜드 ID")
+        Long brandId
+    );
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/brand/BrandV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/brand/BrandV1Controller.java
@@ -1,0 +1,27 @@
+package com.loopers.interfaces.api.brand;
+
+import com.loopers.application.brand.usecase.query.QueryBrandDetailUseCase;
+import com.loopers.application.brand.usecase.query.QueryBrandDetailUseCase.Query;
+import com.loopers.interfaces.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/brands")
+public class BrandV1Controller implements BrandV1ApiSpec {
+
+    private final QueryBrandDetailUseCase queryBrandDetailUseCase;
+
+    @Override
+    @GetMapping("/{brandId}")
+    public ApiResponse<BrandV1Dto.BrandResponse> getBrand(@PathVariable("brandId") Long brandId) {
+        return ApiResponse.success(BrandV1Dto.BrandResponse.from(
+            queryBrandDetailUseCase.execute(new Query(brandId)).brandInfo()
+        ));
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/brand/BrandV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/brand/BrandV1Dto.java
@@ -1,0 +1,21 @@
+package com.loopers.interfaces.api.brand;
+
+import com.loopers.application.brand.dto.BrandInfo;
+import com.loopers.application.product.dto.ProductInfo;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public class BrandV1Dto {
+    public record BrandResponse(Long id, String name, String description, List<ProductResponse> products) {
+        public static BrandResponse from(BrandInfo brand) {
+            return new BrandResponse(brand.id(), brand.name(), brand.description(), brand.products().stream().map(ProductResponse::from).toList());
+        }
+
+        public record ProductResponse(Long id, String name, BigDecimal price, long likeCount) {
+            public static ProductResponse from(ProductInfo product) {
+                return new ProductResponse(product.id(), product.name(), product.price(), product.likeCount());
+            }
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1ApiSpec.java
@@ -1,0 +1,33 @@
+package com.loopers.interfaces.api.like;
+
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Like V1 API")
+public interface LikeV1ApiSpec {
+
+    @Operation(
+        summary = "상품 좋아요 등록"
+    )
+    ApiResponse<LikeV1Dto.LikeResponse> likeProduct(
+        String userId,
+        Long productId
+    );
+
+    @Operation(
+        summary = "상품 좋아요 취소"
+    )
+    ApiResponse<LikeV1Dto.LikeResponse> unlikeProduct(
+        String userId,
+        Long productId
+    );
+
+    @Operation(
+        summary = "내가 좋아요 한 상품 목록 조회"
+    )
+    ApiResponse<LikeV1Dto.GetLikedProductsResponse> getLikedProducts(
+        String userId,
+        LikeV1Dto.GetLikedProductsRequest dto
+    );
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1Controller.java
@@ -1,0 +1,86 @@
+package com.loopers.interfaces.api.like;
+
+import com.loopers.application.like.usecase.command.CommandMarkLikeUseCase;
+import com.loopers.application.like.usecase.command.CommandUnmarkLikeUseCase;
+import com.loopers.application.like.usecase.query.QueryMemberLikedProductsUseCase;
+import com.loopers.application.member.MemberFacade;
+import com.loopers.application.member.MemberInfo;
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.interfaces.api.like.LikeV1Dto.GetLikedProductsResponse;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/like")
+public class LikeV1Controller implements LikeV1ApiSpec {
+
+    private final CommandMarkLikeUseCase commandMarkLikeUseCase;
+    private final CommandUnmarkLikeUseCase commandUnmarkLikeUseCase;
+    private final QueryMemberLikedProductsUseCase queryMemberLikedProductsUseCase;
+    private final MemberFacade memberFacade;
+
+    @Override
+    @PostMapping("/products/{productId}")
+    public ApiResponse<LikeV1Dto.LikeResponse> likeProduct(
+        @RequestHeader(value = "X-USER-ID", required = false) String userId,
+        @PathVariable("productId") Long productId
+    ) {
+        if (userId == null) {
+            throw new CoreException(ErrorType.UNAUTHORIZED);
+        }
+        MemberInfo memberInfo = memberFacade.getMember(userId);
+        if (memberInfo == null) {
+            throw new CoreException(ErrorType.UNAUTHORIZED);
+        }
+
+        commandMarkLikeUseCase.execute(new CommandMarkLikeUseCase.Command(memberInfo, productId));
+        return ApiResponse.success(LikeV1Dto.LikeResponse.from(userId, productId, true));
+    }
+
+    @Override
+    @DeleteMapping("/products/{productId}")
+    public ApiResponse<LikeV1Dto.LikeResponse> unlikeProduct(
+        @RequestHeader(value = "X-USER-ID", required = false) String userId,
+        @PathVariable("productId") Long productId
+    ) {
+        if (userId == null) {
+            throw new CoreException(ErrorType.UNAUTHORIZED);
+        }
+        MemberInfo memberInfo = memberFacade.getMember(userId);
+        if (memberInfo == null) {
+            throw new CoreException(ErrorType.UNAUTHORIZED);
+        }
+
+        commandUnmarkLikeUseCase.execute(new CommandUnmarkLikeUseCase.Command(memberInfo, productId));
+        return ApiResponse.success(LikeV1Dto.LikeResponse.from(userId, productId, false));
+    }
+
+    @Override
+    @GetMapping("/products")
+    public ApiResponse<GetLikedProductsResponse> getLikedProducts(
+        @RequestHeader(value = "X-USER-ID", required = false) String userId,
+        @ModelAttribute LikeV1Dto.GetLikedProductsRequest dto
+    ) {
+        if (userId == null) {
+            throw new CoreException(ErrorType.UNAUTHORIZED);
+        }
+        MemberInfo memberInfo = memberFacade.getMember(userId);
+        if (memberInfo == null) {
+            throw new CoreException(ErrorType.UNAUTHORIZED);
+        }
+        PageRequest pageRequest = PageRequest.of(dto.page(), dto.size());
+
+        QueryMemberLikedProductsUseCase.Result result = queryMemberLikedProductsUseCase.execute(new QueryMemberLikedProductsUseCase.Query(memberInfo, pageRequest));
+
+        return ApiResponse.success(
+            GetLikedProductsResponse.from(
+                GetLikedProductsResponse.MemberResponse.from(result.member()),
+                result.products().map(GetLikedProductsResponse.ProductResponse::from)
+            )
+        );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1Dto.java
@@ -1,0 +1,64 @@
+package com.loopers.interfaces.api.like;
+
+import com.loopers.application.member.MemberInfo;
+import com.loopers.application.product.dto.ProductInfo;
+import com.loopers.domain.member.enums.Gender;
+import org.springframework.data.domain.Page;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public class LikeV1Dto {
+    public record LikeResponse(
+        String userId,
+        Long productId,
+        boolean liked
+    ) {
+        public static LikeResponse from(String userId, Long productId, boolean liked) {
+            return new LikeResponse(userId, productId, liked);
+        }
+    }
+
+    public record GetLikedProductsRequest(
+        Integer page,
+        Integer size
+    ) {
+        public GetLikedProductsRequest {
+            if (page == null || page < 0) {
+                page = 0;
+            }
+            if (size == null || size <= 0) {
+                size = 20;
+            }
+        }
+    }
+
+    public record GetLikedProductsResponse(
+        MemberResponse member,
+        Page<ProductResponse> products
+    ) {
+        public static GetLikedProductsResponse from(MemberResponse member, Page<ProductResponse> products) {
+            return new GetLikedProductsResponse(member, products);
+        }
+
+        public record MemberResponse(String userId, Gender gender, LocalDate birthdate, String email, Long points) {
+            public static MemberResponse from(MemberInfo member) {
+                return new MemberResponse(
+                    member.userId(),
+                    member.gender(),
+                    member.birthdate(),
+                    member.email(),
+                    member.points()
+                );
+            }
+        }
+
+        public record ProductResponse(
+            Long id, String name, BigDecimal price, long likeCount, String brandName
+        ) {
+            public static ProductResponse from(ProductInfo product) {
+                return new ProductResponse(product.id(), product.name(), product.price(), product.likeCount(), product.brandName());
+            }
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/orders/OrderV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/orders/OrderV1ApiSpec.java
@@ -1,0 +1,28 @@
+package com.loopers.interfaces.api.orders;
+
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import java.util.List;
+
+@Tag(name = "Order V1 API")
+public interface OrderV1ApiSpec {
+
+    @Operation(summary = "주문 요청")
+    ApiResponse<OrderV1Dto.OrderResponse> order(
+        String userId,
+        OrderV1Dto.OrderRequest dto
+    );
+
+    @Operation(summary = "유저의 주문 목록 조회")
+    ApiResponse<List<OrderV1Dto.OrderResponse>> getOrders(
+        String userId
+    );
+
+    @Operation(summary = "단일 주문 상세 조회")
+    ApiResponse<OrderV1Dto.OrderResponse> getOrder(
+        String userId,
+        Long orderId
+    );
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/orders/OrderV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/orders/OrderV1Controller.java
@@ -1,0 +1,106 @@
+package com.loopers.interfaces.api.orders;
+
+import com.loopers.application.member.MemberFacade;
+import com.loopers.application.member.MemberInfo;
+import com.loopers.application.orders.usecase.command.CommandOrderUseCase;
+import com.loopers.application.orders.usecase.query.QueryMemberOrdersUseCase;
+import com.loopers.application.orders.usecase.query.QueryOrderDetailUseCase;
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/orders")
+public class OrderV1Controller implements OrderV1ApiSpec {
+
+    private final MemberFacade memberFacade;
+    private final CommandOrderUseCase commandOrderUseCase;
+    private final QueryMemberOrdersUseCase queryMemberOrdersUseCase;
+    private final QueryOrderDetailUseCase queryOrderDetailUseCase;
+
+    @Override
+    @PostMapping()
+    public ApiResponse<OrderV1Dto.OrderResponse> order(
+        @RequestHeader(value = "X-USER-ID", required = false) String userId,
+        @RequestBody OrderV1Dto.OrderRequest dto
+    ) {
+        if (userId == null) {
+            throw new CoreException(ErrorType.UNAUTHORIZED);
+        }
+
+        MemberInfo memberInfo = memberFacade.getMember(userId);
+
+        if (memberInfo == null) {
+            throw new CoreException(ErrorType.UNAUTHORIZED);
+        }
+
+        List<Long> productIds = dto.items().stream()
+            .map(OrderV1Dto.OrderRequest.OrderItemRequest::productId)
+            .toList();
+        List<Long> quantities = dto.items().stream()
+            .map(OrderV1Dto.OrderRequest.OrderItemRequest::quantity)
+            .toList();
+
+        var result = commandOrderUseCase.execute(
+            new CommandOrderUseCase.Command(
+                memberInfo,
+                productIds,
+                quantities,
+                dto.couponId()
+            )
+        );
+
+        return ApiResponse.success(OrderV1Dto.OrderResponse.from(result.orderInfo()));
+    }
+
+    @Override
+    @GetMapping()
+    public ApiResponse<List<OrderV1Dto.OrderResponse>> getOrders(
+        @RequestHeader(value = "X-USER-ID", required = false) String userId
+    ) {
+        if (userId == null) {
+            throw new CoreException(ErrorType.UNAUTHORIZED);
+        }
+
+        MemberInfo memberInfo = memberFacade.getMember(userId);
+
+        if (memberInfo == null) {
+            throw new CoreException(ErrorType.UNAUTHORIZED);
+        }
+
+        var result = queryMemberOrdersUseCase.execute(
+            new QueryMemberOrdersUseCase.Query(memberInfo)
+        );
+
+        return ApiResponse.success(
+            result.orders().stream().map(OrderV1Dto.OrderResponse::from).toList()
+        );
+    }
+
+    @Override
+    @GetMapping("/{orderId}")
+    public ApiResponse<OrderV1Dto.OrderResponse> getOrder(
+        @RequestHeader(value = "X-USER-ID", required = false) String userId,
+        @PathVariable("orderId") Long orderId
+    ) {
+        if (userId == null) {
+            throw new CoreException(ErrorType.UNAUTHORIZED);
+        }
+
+        MemberInfo memberInfo = memberFacade.getMember(userId);
+
+        if (memberInfo == null) {
+            throw new CoreException(ErrorType.UNAUTHORIZED);
+        }
+
+        var query = new QueryOrderDetailUseCase.Query(orderId, memberInfo);
+        var result = queryOrderDetailUseCase.execute(query);
+
+        return ApiResponse.success(OrderV1Dto.OrderResponse.from(result.orderInfo()));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/orders/OrderV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/orders/OrderV1Dto.java
@@ -1,0 +1,54 @@
+package com.loopers.interfaces.api.orders;
+
+import com.loopers.application.orders.dto.OrderInfo;
+import com.loopers.application.orders.dto.OrderItemInfo;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public class OrderV1Dto {
+    public record OrderResponse(
+        Long id, Long memberId, BigDecimal totalPrice, String status, List<OrderItemResponse> items
+    ) {
+        public static OrderResponse from(
+            OrderInfo orderInfo
+        ) {
+            return new OrderResponse(
+                orderInfo.id(),
+                orderInfo.memberId(),
+                orderInfo.totalPrice(),
+                orderInfo.status(),
+                orderInfo.items().stream().map(OrderItemResponse::from).toList()
+            );
+        }
+
+        public record OrderItemResponse(
+            Long productId,
+            String productName,
+            BigDecimal price,
+            Long quantity
+        ) {
+            public static OrderItemResponse from(
+                OrderItemInfo item
+            ) {
+                return new OrderItemResponse(
+                    item.productId(),
+                    item.productName(),
+                    item.price(),
+                    item.quantity()
+                );
+            }
+        }
+    }
+
+    public record OrderRequest(
+        List<OrderItemRequest> items,
+        Long couponId
+    ) {
+        public record OrderItemRequest(
+            Long productId,
+            Long quantity
+        ) {
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1ApiSpec.java
@@ -1,0 +1,24 @@
+package com.loopers.interfaces.api.product;
+
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Page;
+
+@Tag(name = "Product V1 API")
+public interface ProductV1ApiSpec {
+
+    @Operation(
+        summary = "상품 목록 조회"
+    )
+    ApiResponse<Page<ProductV1Dto.ProductResponse>> getProducts(
+        ProductV1Dto.GetProductsRequest dto
+    );
+
+    @Operation(
+        summary = "상품 정보 조회"
+    )
+    ApiResponse<ProductV1Dto.ProductResponse> getProduct(
+        Long productId
+    );
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Controller.java
@@ -1,0 +1,63 @@
+package com.loopers.interfaces.api.product;
+
+import com.loopers.application.product.dto.ProductInfo;
+import com.loopers.application.product.usecase.query.QueryPagedProductsUseCase;
+import com.loopers.application.product.usecase.query.QueryProductDetailUseCase;
+import com.loopers.interfaces.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/products")
+public class ProductV1Controller implements ProductV1ApiSpec {
+
+    private final QueryPagedProductsUseCase queryPagedProductsUseCase;
+    private final QueryProductDetailUseCase queryProductDetailUseCase;
+
+    @Override
+    @GetMapping()
+    public ApiResponse<Page<ProductV1Dto.ProductResponse>> getProducts(
+        @ModelAttribute ProductV1Dto.GetProductsRequest dto
+    ) {
+        Sort sort = parseSort(dto.sort());
+        PageRequest pageRequest = PageRequest.of(dto.page(), dto.size(), sort);
+
+        Page<ProductInfo> products = queryPagedProductsUseCase.execute(new QueryPagedProductsUseCase.Query(dto.brandId(), pageRequest)).products();
+
+        return ApiResponse.success(products.map(ProductV1Dto.ProductResponse::from));
+    }
+
+    private Sort parseSort(String sortString) {
+        // 기본 정렬: 최신순
+        Sort defaultSort = Sort.by(Sort.Direction.DESC, "latest");
+
+        if (sortString == null || sortString.isBlank()) {
+            return defaultSort;
+        }
+
+        String[] parts = sortString.split("_");
+        if (parts.length != 2) {
+            // 형식이 맞지 않으면 기본 정렬 반환
+            return defaultSort;
+        }
+
+        String property = parts[0];
+        String directionString = parts[1];
+
+        Sort.Direction direction = "desc".equalsIgnoreCase(directionString) ?
+            Sort.Direction.DESC : Sort.Direction.ASC;
+
+        return Sort.by(direction, property);
+    }
+
+    @Override
+    @GetMapping("/{productId}")
+    public ApiResponse<ProductV1Dto.ProductResponse> getProduct(@PathVariable("productId") Long productId) {
+        ProductInfo product = queryProductDetailUseCase.execute(new QueryProductDetailUseCase.Query(productId)).product();
+        return ApiResponse.success(ProductV1Dto.ProductResponse.from(product));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Dto.java
@@ -1,0 +1,37 @@
+package com.loopers.interfaces.api.product;
+
+import com.loopers.application.product.dto.ProductInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.math.BigDecimal;
+
+public class ProductV1Dto {
+    public record ProductResponse(
+        Long id, String name, BigDecimal price, Long stock, long likeCount, String brandName
+    ) {
+        public static ProductResponse from(ProductInfo product) {
+            return new ProductResponse(product.id(), product.name(), product.price(), product.stock(), product.likeCount(), product.brandName());
+        }
+    }
+
+    public record GetProductsRequest(
+        @Schema(name = "브랜드 ID")
+        Long brandId,
+        @Schema(name = "정렬 기준", example = "price_asc", allowableValues = {"price_asc", "price_desc", "latest", "likes_asc", "likes_desc"})
+        String sort,
+        @Schema(name = "페이지 번호")
+        Integer page,
+        @Schema(name = "페이지 크기")
+        Integer size
+    ) {
+        public GetProductsRequest {
+            if (page == null || page < 0) {
+                page = 0;
+            }
+            if (size == null || size <= 0) {
+                size = 20;
+            }
+        }
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/support/error/ErrorType.java
+++ b/apps/commerce-api/src/main/java/com/loopers/support/error/ErrorType.java
@@ -14,7 +14,8 @@ public enum ErrorType {
     BAD_REQUEST(HttpStatus.BAD_REQUEST, HttpStatus.BAD_REQUEST.getReasonPhrase(), "잘못된 요청입니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, HttpStatus.NOT_FOUND.getReasonPhrase(), "존재하지 않는 요청입니다."),
     CONFLICT(HttpStatus.CONFLICT, HttpStatus.CONFLICT.getReasonPhrase(), "이미 존재하는 리소스입니다."),
-    FORBIDDEN(HttpStatus.FORBIDDEN, HttpStatus.FORBIDDEN.getReasonPhrase(), "리소스 접근 권한이 없습니다.");
+    FORBIDDEN(HttpStatus.FORBIDDEN, HttpStatus.FORBIDDEN.getReasonPhrase(), "리소스 접근 권한이 없습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, HttpStatus.UNAUTHORIZED.getReasonPhrase(), "인증되지 않은 요청입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/apps/commerce-api/src/test/java/com/loopers/application/like/usecase/command/CommandMarkLikeUseCaseTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/like/usecase/command/CommandMarkLikeUseCaseTest.java
@@ -3,6 +3,8 @@ package com.loopers.application.like.usecase.command;
 import com.loopers.application.like.usecase.command.CommandMarkLikeUseCase.Command;
 import com.loopers.application.member.MemberInfo;
 import com.loopers.domain.like.LikeRepository;
+import com.loopers.domain.member.MemberModel;
+import com.loopers.domain.member.MemberRepository;
 import com.loopers.domain.member.enums.Gender;
 import com.loopers.utils.DatabaseCleanUp;
 import org.junit.jupiter.api.AfterEach;
@@ -12,6 +14,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.jdbc.Sql;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -27,6 +30,9 @@ class CommandMarkLikeUseCaseTest {
 
     @Autowired
     private LikeRepository likeRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
 
     @Autowired
     private DatabaseCleanUp databaseCleanUp;
@@ -78,5 +84,58 @@ class CommandMarkLikeUseCaseTest {
 
         assertThat(successCount.get()).isEqualTo(threadCount);
         assertThat(likeCount).isEqualTo(1);
+    }
+
+    @Test
+    @Sql(statements = {
+        "INSERT INTO product (id, name, price, stock, brand_id, like_count, created_at, updated_at, deleted_at) VALUES (1, '테스트상품1', 1000, 15, 1, 0, '2023-10-01 00:00:00', '2023-10-01 00:00:00', NULL)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (1, 'testUser1', 'MALE', 'test@test.com', '2024-01-01', 0, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (2, 'testUser2', 'MALE', 'test@test.com', '2024-01-01', 0, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (3, 'testUser3', 'MALE', 'test@test.com', '2024-01-01', 0, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (4, 'testUser4', 'MALE', 'test@test.com', '2024-01-01', 0, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (5, 'testUser5', 'MALE', 'test@test.com', '2024-01-01', 0, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)"
+    })
+    void 동일한_상품에_대해_여러명이_좋아요를_요청해도_상품의_좋아요_개수가_정상_반영되어야_한다() throws InterruptedException {
+        int threadCount = 5;
+        Long productId = 1L;
+        MemberModel m1 = memberRepository.findByUserId("testUser1").orElseThrow();
+        MemberModel m2 = memberRepository.findByUserId("testUser2").orElseThrow();
+        MemberModel m3 = memberRepository.findByUserId("testUser3").orElseThrow();
+        MemberModel m4 = memberRepository.findByUserId("testUser4").orElseThrow();
+        MemberModel m5 = memberRepository.findByUserId("testUser5").orElseThrow();
+        List<MemberInfo> members = List.of(
+            MemberInfo.from(m1),
+            MemberInfo.from(m2),
+            MemberInfo.from(m3),
+            MemberInfo.from(m4),
+            MemberInfo.from(m5)
+        );
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failureCount = new AtomicInteger();
+
+        for (int i = 0; i < threadCount; i++) {
+            final int idx = i;
+            executor.submit(() -> {
+                try {
+                    commandMarkLikeUseCase.execute(new Command(members.get(idx), productId));
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failureCount.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        long likeCount = likeRepository.getProductLikeCount(productId);
+
+        assertThat(successCount.get()).isEqualTo(threadCount);
+        assertThat(likeCount).isEqualTo(threadCount);
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/application/like/usecase/command/CommandMarkLikeUseCaseTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/like/usecase/command/CommandMarkLikeUseCaseTest.java
@@ -1,0 +1,82 @@
+package com.loopers.application.like.usecase.command;
+
+import com.loopers.application.like.usecase.command.CommandMarkLikeUseCase.Command;
+import com.loopers.application.member.MemberInfo;
+import com.loopers.domain.like.LikeRepository;
+import com.loopers.domain.member.enums.Gender;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.time.LocalDate;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+class CommandMarkLikeUseCaseTest {
+
+    @Autowired
+    private CommandMarkLikeUseCase commandMarkLikeUseCase;
+
+    @Autowired
+    private LikeRepository likeRepository;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @Test
+    @Sql(statements = {
+        "INSERT INTO product (id, name, price, stock, brand_id, like_count, created_at, updated_at, deleted_at) VALUES (1, '테스트상품1', 1000, 15, 1, 10, '2023-10-01 00:00:00', '2023-10-01 00:00:00', NULL)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (1, 'testUser', 'MALE', 'test@test.com', '2024-01-01', 0, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)"
+    })
+    void 멱등성_동시에_요청해도_하나만_반영한다() throws InterruptedException {
+        int threadCount = 5;
+        MemberInfo memberInfo = new MemberInfo(
+            1L,
+            "testUser",
+            Gender.MALE,
+            LocalDate.of(2024, 1, 1),
+            "test@test.com",
+            0L
+        );
+        Long productId = 1L;
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failureCount = new AtomicInteger();
+
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    commandMarkLikeUseCase.execute(new Command(memberInfo, productId));
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failureCount.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        long likeCount = likeRepository.getProductLikeCount(productId);
+
+        assertThat(successCount.get()).isEqualTo(threadCount);
+        assertThat(likeCount).isEqualTo(1);
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/application/like/usecase/command/CommandUnmarkLikeUseCaseTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/like/usecase/command/CommandUnmarkLikeUseCaseTest.java
@@ -2,6 +2,8 @@ package com.loopers.application.like.usecase.command;
 
 import com.loopers.application.member.MemberInfo;
 import com.loopers.domain.like.LikeRepository;
+import com.loopers.domain.member.MemberModel;
+import com.loopers.domain.member.MemberRepository;
 import com.loopers.domain.member.enums.Gender;
 import com.loopers.utils.DatabaseCleanUp;
 import org.junit.jupiter.api.AfterEach;
@@ -11,6 +13,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.jdbc.Sql;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -26,6 +29,9 @@ class CommandUnmarkLikeUseCaseTest {
 
     @Autowired
     private LikeRepository likeRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
 
     @Autowired
     private DatabaseCleanUp databaseCleanUp;
@@ -82,5 +88,63 @@ class CommandUnmarkLikeUseCaseTest {
 
         assertThat(successCount.get()).isEqualTo(threadCount);
         assertThat(likeCount).isEqualTo(2);
+    }
+
+    @Test
+    @Sql(statements = {
+        "INSERT INTO product (id, name, price, stock, brand_id, like_count, created_at, updated_at, deleted_at) VALUES (1, '테스트상품1', 1000, 15, 1, 5, '2023-10-01 00:00:00', '2023-10-01 00:00:00', NULL)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (1, 'testUser1', 'MALE', 'test@test.com', '2024-01-01', 0, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (2, 'testUser2', 'MALE', 'test@test.com', '2024-01-01', 0, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (3, 'testUser3', 'MALE', 'test@test.com', '2024-01-01', 0, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (4, 'testUser4', 'MALE', 'test@test.com', '2024-01-01', 0, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (5, 'testUser5', 'MALE', 'test@test.com', '2024-01-01', 0, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)",
+        "insert into likes (created_at, member_id, product_id) values ('2023-10-01 12:00:00', 1, 1)",
+        "insert into likes (created_at, member_id, product_id) values ('2023-10-01 12:00:00', 2, 1)",
+        "insert into likes (created_at, member_id, product_id) values ('2023-10-01 12:00:00', 3, 1)",
+        "insert into likes (created_at, member_id, product_id) values ('2023-10-01 12:00:00', 4, 1)",
+        "insert into likes (created_at, member_id, product_id) values ('2023-10-01 12:00:00', 5, 1)"
+    })
+    void 동일한_상품에_대해_여러명이_좋아요를_취소해도_상품의_좋아요_개수가_정상_반영되어야_한다() throws InterruptedException {
+        int threadCount = 5;
+        Long productId = 1L;
+        MemberModel m1 = memberRepository.findByUserId("testUser1").orElseThrow();
+        MemberModel m2 = memberRepository.findByUserId("testUser2").orElseThrow();
+        MemberModel m3 = memberRepository.findByUserId("testUser3").orElseThrow();
+        MemberModel m4 = memberRepository.findByUserId("testUser4").orElseThrow();
+        MemberModel m5 = memberRepository.findByUserId("testUser5").orElseThrow();
+        List<MemberInfo> members = List.of(
+            MemberInfo.from(m1),
+            MemberInfo.from(m2),
+            MemberInfo.from(m3),
+            MemberInfo.from(m4),
+            MemberInfo.from(m5)
+        );
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failureCount = new AtomicInteger();
+
+        for (int i = 0; i < threadCount; i++) {
+            final int idx = i;
+            executor.submit(() -> {
+                try {
+                    commandUnmarkLikeUseCase.execute(new CommandUnmarkLikeUseCase.Command(members.get(idx), productId));
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failureCount.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        long likeCount = likeRepository.getProductLikeCount(productId);
+
+        assertThat(successCount.get()).isEqualTo(threadCount);
+        assertThat(likeCount).isEqualTo(0);
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/application/like/usecase/command/CommandUnmarkLikeUseCaseTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/like/usecase/command/CommandUnmarkLikeUseCaseTest.java
@@ -1,0 +1,86 @@
+package com.loopers.application.like.usecase.command;
+
+import com.loopers.application.member.MemberInfo;
+import com.loopers.domain.like.LikeRepository;
+import com.loopers.domain.member.enums.Gender;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.time.LocalDate;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+class CommandUnmarkLikeUseCaseTest {
+
+    @Autowired
+    private CommandUnmarkLikeUseCase commandUnmarkLikeUseCase;
+
+    @Autowired
+    private LikeRepository likeRepository;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @Test
+    @Sql(statements = {
+        "INSERT INTO product (id, name, price, stock, brand_id, like_count, created_at, updated_at, deleted_at) VALUES (1, '테스트상품1', 1000, 15, 1, 3, '2023-10-01 00:00:00', '2023-10-01 00:00:00', NULL)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (1, 'testUser1', 'MALE', 'test@test.com', '2024-01-01', 0, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (2, 'testUser2', 'MALE', 'test@test.com', '2024-01-01', 0, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (3, 'testUser3', 'MALE', 'test@test.com', '2024-01-01', 0, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)",
+        "insert into likes (created_at, member_id, product_id) values ('2023-10-01 12:00:00', 1, 1);",
+        "insert into likes (created_at, member_id, product_id) values ('2023-10-01 12:00:00', 2, 1);",
+        "insert into likes (created_at, member_id, product_id) values ('2023-10-01 12:00:00', 3, 1);"
+    })
+    void 멱등성_동시에_요청해도_같은_결과를_반환한다() throws InterruptedException {
+        int threadCount = 5;
+        MemberInfo memberInfo = new MemberInfo(
+            1L,
+            "testUser1",
+            Gender.MALE,
+            LocalDate.of(2024, 1, 1),
+            "test@test.com",
+            0L
+        );
+        Long productId = 1L;
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failureCount = new AtomicInteger();
+
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    commandUnmarkLikeUseCase.execute(new CommandUnmarkLikeUseCase.Command(memberInfo, productId));
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failureCount.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        long likeCount = likeRepository.getProductLikeCount(productId);
+
+        assertThat(successCount.get()).isEqualTo(threadCount);
+        assertThat(likeCount).isEqualTo(2);
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/application/orders/usecase/command/CommandOrderUseCaseTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/orders/usecase/command/CommandOrderUseCaseTest.java
@@ -1,19 +1,26 @@
 package com.loopers.application.orders.usecase.command;
 
 import com.loopers.application.member.MemberInfo;
+import com.loopers.application.orders.usecase.command.CommandOrderUseCase.Command;
+import com.loopers.application.orders.usecase.command.CommandOrderUseCase.Result;
+import com.loopers.domain.coupon.CouponModel;
+import com.loopers.domain.coupon.CouponRepository;
 import com.loopers.domain.member.MemberModel;
 import com.loopers.domain.member.MemberRepository;
-import com.loopers.domain.member.enums.Gender;
+import com.loopers.domain.orders.ExternalServiceOutputPort;
+import com.loopers.domain.orders.OrderRepository;
+import com.loopers.domain.orders.OrdersModel;
 import com.loopers.domain.product.ProductModel;
 import com.loopers.domain.product.ProductRepository;
+import com.loopers.support.error.CoreException;
 import com.loopers.utils.DatabaseCleanUp;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.jdbc.Sql;
 
-import java.time.LocalDate;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -21,6 +28,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 class CommandOrderUseCaseTest {
@@ -35,6 +45,15 @@ class CommandOrderUseCaseTest {
     private ProductRepository productRepository;
 
     @Autowired
+    private OrderRepository orderRepository;
+
+    @Autowired
+    private CouponRepository couponRepository;
+
+    @MockitoBean
+    private ExternalServiceOutputPort deliveryClient;
+
+    @Autowired
     private DatabaseCleanUp databaseCleanUp;
 
     @AfterEach
@@ -47,20 +66,15 @@ class CommandOrderUseCaseTest {
         "INSERT INTO product (id, name, price, stock, brand_id, like_count, created_at, updated_at, deleted_at) VALUES (1, '테스트상품1', 1000, 15, 1, 10, '2023-10-01 00:00:00', '2023-10-01 00:00:00', NULL)",
         "INSERT INTO product (id, name, price, stock, brand_id, like_count, created_at, updated_at, deleted_at) VALUES (2, '테스트상품2', 2000, 10, 1, 10, '2023-10-01 00:00:00', '2023-10-01 00:00:00', NULL)",
         "INSERT INTO product (id, name, price, stock, brand_id, like_count, created_at, updated_at, deleted_at) VALUES (3, '테스트상품3', 3000, 5, 1, 10, '2023-10-01 00:00:00', '2023-10-01 00:00:00', NULL)",
-        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (1, 'testUser', 'MALE', 'test@test.com', '2024-01-01', 10000, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)"
+        "INSERT INTO product (id, name, price, stock, brand_id, like_count, created_at, updated_at, deleted_at) VALUES (4, '테스트상품4', 4000, 5, 1, 10, '2023-10-01 00:00:00', '2023-10-01 00:00:00', NULL)",
+        "INSERT INTO product (id, name, price, stock, brand_id, like_count, created_at, updated_at, deleted_at) VALUES (5, '테스트상품5', 5000, 5, 1, 10, '2023-10-01 00:00:00', '2023-10-01 00:00:00', NULL)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (1, 'testUser', 'MALE', 'test@test.com', '2024-01-01', 20000, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)"
     })
-    void 동일한_유저가_여러_기기에서_동시에_주문해도_포인트가_중복_차감되지_않아야_한다() throws InterruptedException {
-        final int threadCount = 20;
-        MemberInfo memberInfo = new MemberInfo(
-            1L,
-            "testUser",
-            Gender.MALE,
-            LocalDate.of(2024, 1, 1),
-            "test@test.com",
-            10000L
-        );
-        List<Long> productIds = List.of(1L, 2L, 3L);
-        List<Long> quantities = List.of(1L, 1L, 1L);
+    void 동일한_유저가_서로_다른_주문을_동시에_수행해도_포인트가_정상적으로_차감되어야_한다() throws InterruptedException {
+        final int threadCount = 5;
+        MemberInfo memberInfo = MemberInfo.from(memberRepository.findByUserId("testUser").orElseThrow());
+        List<Long> productIds = List.of(1L, 2L, 3L, 4L, 5L);
+        List<Long> quantities = List.of(1L, 1L, 1L, 1L, 1L);
 
         ExecutorService executor = Executors.newFixedThreadPool(threadCount);
         CountDownLatch latch = new CountDownLatch(threadCount);
@@ -69,9 +83,10 @@ class CommandOrderUseCaseTest {
         AtomicInteger failureCount = new AtomicInteger();
 
         for (int i = 0; i < threadCount; i++) {
+            final int itemIndex = i % productIds.size();
             executor.submit(() -> {
                 try {
-                    commandOrderUseCase.execute(new CommandOrderUseCase.Command(memberInfo, productIds, quantities));
+                    commandOrderUseCase.execute(new Command(memberInfo, List.of(productIds.get(itemIndex)), List.of(quantities.get(itemIndex)), null));
                     successCount.incrementAndGet();
                 } catch (Exception e) {
                     failureCount.incrementAndGet();
@@ -85,9 +100,8 @@ class CommandOrderUseCaseTest {
 
         MemberModel member = memberRepository.findByUserId("testUser").orElseThrow();
 
-        assertThat(failureCount.get()).isEqualTo(19);
-        assertThat(successCount.get()).isEqualTo(1);
-        assertThat(member.getPoints()).isEqualTo(4000L);
+        assertThat(successCount.get()).isEqualTo(threadCount);
+        assertThat(member.getPoints()).isEqualTo(5000L);
     }
 
     @Test
@@ -121,7 +135,7 @@ class CommandOrderUseCaseTest {
             final int memberIndex = i % memberInfos.size();
             executor.submit(() -> {
                 try {
-                    commandOrderUseCase.execute(new CommandOrderUseCase.Command(memberInfos.get(memberIndex), productIds, quantities));
+                    commandOrderUseCase.execute(new Command(memberInfos.get(memberIndex), productIds, quantities, null));
                     successCount.incrementAndGet();
                 } catch (Exception e) {
                     failureCount.incrementAndGet();
@@ -138,5 +152,161 @@ class CommandOrderUseCaseTest {
 
         assertThat(failureCount.get()).isEqualTo(0);
         assertThat(successCount.get()).isEqualTo(threadCount);
+    }
+
+    @Test
+    @Sql(statements = {
+        "INSERT INTO product (id, name, price, stock, brand_id, like_count, created_at, updated_at, deleted_at) VALUES (1, '테스트상품1', 1000, 15, 1, 10, '2023-10-01 00:00:00', '2023-10-01 00:00:00', NULL)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (1, 'testUser1', 'MALE', 'test@test.com', '2024-01-01', 10000, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)",
+        "insert into coupon (id, amount, rate, created_at, deleted_at, issued_at, member_id, code, discount_type, target_scope, version) values (1, 500, null, '2023-10-01 12:00:00', null, '2023-10-01 12:00:00', 1, 'COUPON_12345', 'FIXED_AMOUNT', 'ORDER', 0)"
+    })
+    void 동일한_쿠폰으로_여러_기기에서_동시에_주문해도_쿠폰은_단_한번만_사용되어야_한다() throws InterruptedException {
+        final int threadCount = 5;
+        MemberModel member = memberRepository.findByUserId("testUser1").orElseThrow();
+        Long couponId = 1L;
+
+        List<Long> productIds = List.of(1L);
+        List<Long> quantities = List.of(1L);
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failureCount = new AtomicInteger();
+
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    commandOrderUseCase.execute(new Command(MemberInfo.from(member), productIds, quantities, couponId));
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failureCount.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        CouponModel couponModel = couponRepository.find(couponId).orElseThrow();
+        List<OrdersModel> orders = orderRepository.searchByCoupon(couponId);
+
+        assertThat(couponModel.getDeletedAt()).isNotNull();
+        assertThat(orders.size()).isEqualTo(1);
+        assertThat(successCount.get()).isEqualTo(1);
+    }
+
+    @Test
+    @Sql(statements = {
+        "INSERT INTO product (id, name, price, stock, brand_id, like_count, created_at, updated_at, deleted_at) VALUES (1, '롤백테스트상품', 1000, 10, 1, 10, '2023-10-01 00:00:00', '2023-10-01 00:00:00', NULL)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (1, 'rollbackUser', 'MALE', 'rollback@test.com', '2024-01-01', 20000, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)"
+    })
+    void 주문_처리_중_예외가_발생하면_모든_변경사항이_롤백되어야_한다() {
+        // given
+        MemberModel memberBefore = memberRepository.findByUserId("rollbackUser").orElseThrow();
+        ProductModel productBefore = productRepository.find(1L).orElseThrow();
+        Command command = new Command(MemberInfo.from(memberBefore), List.of(1L), List.of(1L), null);
+
+        doThrow(new RuntimeException("Delivery service failed")).when(deliveryClient).send(any(OrdersModel.class));
+
+        // when
+        assertThrows(CoreException.class, () -> {
+            commandOrderUseCase.execute(command);
+        });
+
+        // then
+        MemberModel memberAfter = memberRepository.findByUserId("rollbackUser").orElseThrow();
+        assertThat(memberAfter.getPoints()).isEqualTo(memberBefore.getPoints());
+
+        ProductModel productAfter = productRepository.find(1L).orElseThrow();
+        assertThat(productAfter.getStock().getQuantity()).isEqualTo(productBefore.getStock().getQuantity());
+
+        List<OrdersModel> orders = orderRepository.search(memberBefore.getId());
+        assertThat(orders).isEmpty();
+    }
+
+    @Test
+    @Sql(statements = {
+        "INSERT INTO product (id, name, price, stock, brand_id, like_count, created_at, updated_at, deleted_at) VALUES (1, '테스트상품1', 1000, 15, 1, 10, '2023-10-01 00:00:00', '2023-10-01 00:00:00', NULL)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (1, 'testUser1', 'MALE', 'test@test.com', '2024-01-01', 10000, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)",
+        "insert into coupon (id, amount, rate, created_at, deleted_at, issued_at, member_id, code, discount_type, target_scope, version) values (1, 500, null, '2023-10-01 12:00:00', '2023-10-02 12:00:00', '2023-10-01 12:00:00', 1, 'USED_COUPON', 'FIXED_AMOUNT', 'ORDER', 0)"
+    })
+    void 사용할_수_없는_쿠폰으로_주문하면_실패해야_한다() {
+        // given
+        MemberModel member = memberRepository.findByUserId("testUser1").orElseThrow();
+        Command commandWithUsedCoupon = new Command(MemberInfo.from(member), List.of(1L), List.of(1L), 1L);
+        Command commandWithNonExistentCoupon = new Command(MemberInfo.from(member), List.of(1L), List.of(1L), 999L);
+
+        // when & then
+        assertThrows(CoreException.class, () -> {
+            commandOrderUseCase.execute(commandWithUsedCoupon);
+        });
+        assertThrows(CoreException.class, () -> {
+            commandOrderUseCase.execute(commandWithNonExistentCoupon);
+        });
+    }
+
+    @Test
+    @Sql(statements = {
+        "INSERT INTO product (id, name, price, stock, brand_id, like_count, created_at, updated_at, deleted_at) VALUES (1, '재고부족상품', 1000, 1, 1, 10, '2023-10-01 00:00:00', '2023-10-01 00:00:00', NULL)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (1, 'testUser1', 'MALE', 'test@test.com', '2024-01-01', 10000, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)"
+    })
+    void 재고가_부족하면_주문은_실패해야_한다() {
+        // given
+        MemberModel member = memberRepository.findByUserId("testUser1").orElseThrow();
+        // 재고(1)보다 많은 수량(2)을 주문
+        Command command = new Command(MemberInfo.from(member), List.of(1L), List.of(2L), null);
+
+        // when & then
+        assertThrows(CoreException.class, () -> {
+            commandOrderUseCase.execute(command);
+        });
+    }
+
+    @Test
+    @Sql(statements = {
+        "INSERT INTO product (id, name, price, stock, brand_id, like_count, created_at, updated_at, deleted_at) VALUES (1, '고가상품', 20000, 10, 1, 10, '2023-10-01 00:00:00', '2023-10-01 00:00:00', NULL)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (1, 'testUser1', 'MALE', 'poor@test.com', '2024-01-01', 10000, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)"
+    })
+    void 포인트가_부족하면_주문은_실패해야_한다() {
+        // given
+        MemberModel member = memberRepository.findByUserId("testUser1").orElseThrow();
+        // 보유 포인트(10000)보다 비싼 상품(20000) 주문
+        Command command = new Command(MemberInfo.from(member), List.of(1L), List.of(1L), null);
+
+        // when & then
+        assertThrows(CoreException.class, () -> {
+            commandOrderUseCase.execute(command);
+        });
+    }
+
+    @Test
+    @Sql(statements = {
+        "INSERT INTO product (id, name, price, stock, brand_id, like_count, created_at, updated_at, deleted_at) VALUES (1, '성공테스트상품', 1000, 10, 1, 10, '2023-10-01 00:00:00', '2023-10-01 00:00:00', NULL)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (1, 'successUser', 'MALE', 'success@test.com', '2024-01-01', 10000, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)"
+    })
+    void 주문에_성공하면_재고와_포인트가_정상적으로_차감되고_주문이_생성되어야_한다() {
+        // given
+        MemberModel member = memberRepository.findByUserId("successUser").orElseThrow();
+        Command command = new Command(MemberInfo.from(member), List.of(1L), List.of(2L), null);
+
+        // when
+        Result result = commandOrderUseCase.execute(command);
+
+        // then
+        // 주문 생성 확인
+        assertThat(result.orderInfo().id()).isNotNull();
+        OrdersModel order = orderRepository.find(result.orderInfo().id()).orElseThrow();
+        assertThat(order.getMemberId()).isEqualTo(member.getId());
+        assertThat(order.getItems()).hasSize(1);
+
+        // 재고 차감 확인
+        ProductModel productAfter = productRepository.find(1L).orElseThrow();
+        assertThat(productAfter.getStock().getQuantity()).isEqualTo(8L); // 10 - 2
+
+        // 포인트 차감 확인
+        MemberModel memberAfter = memberRepository.findByUserId("successUser").orElseThrow();
+        assertThat(memberAfter.getPoints()).isEqualTo(8000L); // 10000 - (1000 * 2)
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/application/orders/usecase/command/CommandOrderUseCaseTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/orders/usecase/command/CommandOrderUseCaseTest.java
@@ -1,0 +1,142 @@
+package com.loopers.application.orders.usecase.command;
+
+import com.loopers.application.member.MemberInfo;
+import com.loopers.domain.member.MemberModel;
+import com.loopers.domain.member.MemberRepository;
+import com.loopers.domain.member.enums.Gender;
+import com.loopers.domain.product.ProductModel;
+import com.loopers.domain.product.ProductRepository;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+class CommandOrderUseCaseTest {
+
+    @Autowired
+    private CommandOrderUseCase commandOrderUseCase;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @Test
+    @Sql(statements = {
+        "INSERT INTO product (id, name, price, stock, brand_id, like_count, created_at, updated_at, deleted_at) VALUES (1, '테스트상품1', 1000, 15, 1, 10, '2023-10-01 00:00:00', '2023-10-01 00:00:00', NULL)",
+        "INSERT INTO product (id, name, price, stock, brand_id, like_count, created_at, updated_at, deleted_at) VALUES (2, '테스트상품2', 2000, 10, 1, 10, '2023-10-01 00:00:00', '2023-10-01 00:00:00', NULL)",
+        "INSERT INTO product (id, name, price, stock, brand_id, like_count, created_at, updated_at, deleted_at) VALUES (3, '테스트상품3', 3000, 5, 1, 10, '2023-10-01 00:00:00', '2023-10-01 00:00:00', NULL)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (1, 'testUser', 'MALE', 'test@test.com', '2024-01-01', 10000, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)"
+    })
+    void 동일한_유저가_여러_기기에서_동시에_주문해도_포인트가_중복_차감되지_않아야_한다() throws InterruptedException {
+        final int threadCount = 20;
+        MemberInfo memberInfo = new MemberInfo(
+            1L,
+            "testUser",
+            Gender.MALE,
+            LocalDate.of(2024, 1, 1),
+            "test@test.com",
+            10000L
+        );
+        List<Long> productIds = List.of(1L, 2L, 3L);
+        List<Long> quantities = List.of(1L, 1L, 1L);
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failureCount = new AtomicInteger();
+
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    commandOrderUseCase.execute(new CommandOrderUseCase.Command(memberInfo, productIds, quantities));
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failureCount.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        MemberModel member = memberRepository.findByUserId("testUser").orElseThrow();
+
+        assertThat(failureCount.get()).isEqualTo(19);
+        assertThat(successCount.get()).isEqualTo(1);
+        assertThat(member.getPoints()).isEqualTo(4000L);
+    }
+
+    @Test
+    @Sql(statements = {
+        "INSERT INTO product (id, name, price, stock, brand_id, like_count, created_at, updated_at, deleted_at) VALUES (1, '테스트상품1', 1000, 15, 1, 10, '2023-10-01 00:00:00', '2023-10-01 00:00:00', NULL)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (1, 'testUser1', 'MALE', 'test@test.com', '2024-01-01', 10000, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (2, 'testUser2', 'MALE', 'test@test.com', '2024-01-01', 10000, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (3, 'testUser3', 'MALE', 'test@test.com', '2024-01-01', 10000, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (4, 'testUser4', 'MALE', 'test@test.com', '2024-01-01', 10000, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)",
+        "INSERT INTO member (id, user_id, gender, email, birthdate, points, created_at, updated_at, deleted_at, version) VALUES (5, 'testUser5', 'MALE', 'test@test.com', '2024-01-01', 10000, '2023-10-03 00:00:00', '2023-10-03 00:00:00', NULL, 0)"
+    })
+    void 동일한_상품에_대해_여러_주문이_동시에_요청되어도_재고가_정상적으로_차감되어야_한다() throws InterruptedException {
+        final int threadCount = 5;
+        MemberModel m1 = memberRepository.findByUserId("testUser1").orElseThrow();
+        MemberModel m2 = memberRepository.findByUserId("testUser2").orElseThrow();
+        MemberModel m3 = memberRepository.findByUserId("testUser3").orElseThrow();
+        MemberModel m4 = memberRepository.findByUserId("testUser4").orElseThrow();
+        MemberModel m5 = memberRepository.findByUserId("testUser5").orElseThrow();
+
+        List<MemberInfo> memberInfos = List.of(MemberInfo.from(m1), MemberInfo.from(m2), MemberInfo.from(m3), MemberInfo.from(m4), MemberInfo.from(m5));
+        List<Long> productIds = List.of(1L);
+        List<Long> quantities = List.of(2L);
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failureCount = new AtomicInteger();
+
+        for (int i = 0; i < threadCount; i++) {
+            final int memberIndex = i % memberInfos.size();
+            executor.submit(() -> {
+                try {
+                    commandOrderUseCase.execute(new CommandOrderUseCase.Command(memberInfos.get(memberIndex), productIds, quantities));
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failureCount.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        ProductModel productModel = productRepository.find(1L).orElseThrow();
+        assertThat(productModel.getStock().getQuantity()).isEqualTo(5L);
+
+        assertThat(failureCount.get()).isEqualTo(0);
+        assertThat(successCount.get()).isEqualTo(threadCount);
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponModelTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponModelTest.java
@@ -1,0 +1,194 @@
+package com.loopers.domain.coupon;
+
+import com.loopers.domain.coupon.CouponModel.TargetScope;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class CouponModelTest {
+
+    @Nested
+    class Create {
+
+        static Stream<Arguments> invalidConstructorArgs() {
+            DiscountMethod validDiscount = new DiscountMethod(0.5);
+            TargetScope validScope = TargetScope.ORDER;
+            return Stream.of(
+                Arguments.of(validDiscount, null),
+                Arguments.of(null, validScope),
+                Arguments.of(null, null)
+            );
+        }
+
+        static Stream<Arguments> invalidConstructorArgsWithMemberId() {
+            DiscountMethod validDiscount = new DiscountMethod(0.5);
+            TargetScope validScope = TargetScope.ORDER;
+            Long validMemberId = 1L;
+            return Stream.of(
+                Arguments.of(validDiscount, validScope, null),
+                Arguments.of(null, validScope, validMemberId),
+                Arguments.of(validDiscount, null, validMemberId)
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("invalidConstructorArgs")
+        void throwsIllegalArgumentException_whenRequiredArgsAreNull(DiscountMethod discountMethod, TargetScope targetScope) {
+            assertThrows(IllegalArgumentException.class, () -> {
+                new CouponModel(discountMethod, targetScope);
+            });
+        }
+
+        @ParameterizedTest
+        @MethodSource("invalidConstructorArgsWithMemberId")
+        void throwsIllegalArgumentException_whenRequiredArgsWithMemberIdAreNull(DiscountMethod discountMethod, TargetScope targetScope, Long memberId) {
+            assertThrows(IllegalArgumentException.class, () -> {
+                new CouponModel(discountMethod, targetScope, memberId);
+            });
+        }
+
+        @Test
+        void createCouponModel_whenValidArgsAreProvided() {
+            DiscountMethod discountMethod = new DiscountMethod(0.5);
+            TargetScope targetScope = TargetScope.ORDER;
+
+            CouponModel couponModel = new CouponModel(discountMethod, targetScope);
+
+            assertThat(couponModel.getCode()).isNotNull();
+            assertThat(couponModel.getDiscountMethod()).isEqualTo(discountMethod);
+            assertThat(couponModel.getTargetScope()).isEqualTo(targetScope);
+        }
+
+        @Test
+        void createCouponModel_whenValidArgsWithMemberIdAreProvided() {
+            DiscountMethod discountMethod = new DiscountMethod(0.5);
+            TargetScope targetScope = TargetScope.ORDER;
+            Long memberId = 1L;
+
+            CouponModel couponModel = new CouponModel(discountMethod, targetScope, memberId);
+
+            assertThat(couponModel.getCode()).isNotNull();
+            assertThat(couponModel.getDiscountMethod()).isEqualTo(discountMethod);
+            assertThat(couponModel.getTargetScope()).isEqualTo(targetScope);
+            assertThat(couponModel.getMemberId()).isEqualTo(memberId);
+            assertThat(couponModel.getIssuedAt()).isNotNull();
+        }
+    }
+
+    @Nested
+    class IssueTo {
+
+        @Test
+        void issueTo_whenAlreadyIssued_throwsIllegalStateException() {
+            DiscountMethod discountMethod = new DiscountMethod(0.5);
+            TargetScope targetScope = TargetScope.ORDER;
+            Long memberId = 1L;
+            CouponModel couponModel = new CouponModel(discountMethod, targetScope, memberId);
+
+            assertThrows(IllegalStateException.class, () -> {
+                couponModel.issueTo(memberId);
+            });
+        }
+
+        @Test
+        void issueTo_whenNotIssued_setsMemberIdAndIssuedAt() {
+            DiscountMethod discountMethod = new DiscountMethod(0.5);
+            TargetScope targetScope = TargetScope.ORDER;
+            Long memberId = 1L;
+
+            CouponModel couponModel = new CouponModel(discountMethod, targetScope);
+
+            couponModel.issueTo(memberId);
+
+            assertThat(couponModel.getMemberId()).isEqualTo(memberId);
+            assertThat(couponModel.getIssuedAt()).isNotNull();
+        }
+    }
+
+    @Nested
+    class Apply {
+        @Test
+        void apply_whenDiscountMethodIsNull_throwsIllegalStateException() throws Exception {
+            CouponModel couponModel = new CouponModel(new DiscountMethod(0.5), TargetScope.ORDER);
+
+            ReflectionTestUtils.setField(couponModel, "discountMethod", null);
+
+            assertThrows(IllegalStateException.class, () -> {
+                couponModel.apply(BigDecimal.valueOf(100));
+            });
+        }
+
+        @Test
+        void apply_whenValidDiscountMethod_appliesDiscount() {
+            DiscountMethod discountMethod = new DiscountMethod(BigDecimal.valueOf(20));
+            CouponModel couponModel = new CouponModel(discountMethod, TargetScope.ORDER);
+
+            BigDecimal originalPrice = BigDecimal.valueOf(100);
+            BigDecimal discountedPrice = couponModel.apply(originalPrice);
+
+            assertThat(discountedPrice).isEqualTo(BigDecimal.valueOf(80));
+        }
+
+        @Test
+        void apply_whenDeletedAtIsNotNull_throwsIllegalStateException() {
+            DiscountMethod discountMethod = new DiscountMethod(0.5);
+            CouponModel couponModel = new CouponModel(discountMethod, TargetScope.ORDER);
+            ReflectionTestUtils.setField(couponModel, "deletedAt", ZonedDateTime.now());
+
+            assertThrows(IllegalStateException.class, () -> {
+                couponModel.apply(BigDecimal.valueOf(100));
+            });
+        }
+
+        @Test
+        void apply_whenApplied_deletesCoupon() {
+            DiscountMethod discountMethod = new DiscountMethod(0.5);
+            CouponModel couponModel = new CouponModel(discountMethod, TargetScope.ORDER);
+
+            BigDecimal originalPrice = BigDecimal.valueOf(100);
+            couponModel.apply(originalPrice);
+
+            assertThat(couponModel.getDeletedAt()).isNotNull();
+        }
+    }
+
+    @Nested
+    class HasOwned {
+
+        @Test
+        void hasOwned_whenGivenMemberIdIsNull_returnsFalse() {
+            CouponModel couponModel = new CouponModel(new DiscountMethod(0.5), TargetScope.ORDER);
+            assertThat(couponModel.hasOwned(null)).isFalse();
+        }
+
+        @Test
+        void hasOwned_whenCouponMemberIdIsNull_returnsFalse() {
+            CouponModel couponModel = new CouponModel(new DiscountMethod(0.5), TargetScope.ORDER);
+            assertThat(couponModel.hasOwned(1L)).isFalse();
+        }
+
+        @Test
+        void hasOwned_whenMemberIdMatches_returnsTrue() {
+            Long memberId = 1L;
+            CouponModel couponModel = new CouponModel(new DiscountMethod(0.5), TargetScope.ORDER, memberId);
+            assertThat(couponModel.hasOwned(memberId)).isTrue();
+        }
+
+        @Test
+        void hasOwned_whenMemberIdDoesNotMatch_returnsFalse() {
+            Long memberId = 1L;
+            CouponModel couponModel = new CouponModel(new DiscountMethod(0.5), TargetScope.ORDER, memberId);
+            assertThat(couponModel.hasOwned(2L)).isFalse();
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/DiscountMethodTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/DiscountMethodTest.java
@@ -1,0 +1,109 @@
+package com.loopers.domain.coupon;
+
+import com.loopers.domain.coupon.DiscountMethod.DiscountType;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class DiscountMethodTest {
+
+    @Nested
+    class Create {
+
+        @Test
+        void throwsException_WhenAmountIsNull() {
+            assertThrows(
+                IllegalArgumentException.class,
+                () -> new DiscountMethod((BigDecimal) null)
+            );
+        }
+
+        @Test
+        void throwsException_WhenRateIsNull() {
+            assertThrows(
+                IllegalArgumentException.class,
+                () -> new DiscountMethod((Double) null)
+            );
+        }
+
+        @Test
+        void create_WithFixedAmount() {
+            DiscountMethod discountMethod = new DiscountMethod(BigDecimal.valueOf(1000));
+
+            assertEquals(DiscountType.FIXED_AMOUNT, discountMethod.getDiscountType());
+            assertEquals(BigDecimal.valueOf(1000), discountMethod.getAmount());
+            assertNull(discountMethod.getRate());
+        }
+
+        @Test
+        void create_WithRate() {
+            DiscountMethod discountMethod = new DiscountMethod(0.1);
+
+            assertEquals(DiscountType.RATE, discountMethod.getDiscountType());
+            assertEquals(0.1, discountMethod.getRate());
+            assertNull(discountMethod.getAmount());
+        }
+    }
+
+    @Nested
+    class ToPolicy {
+        @Test
+        void toPolicy_withFixedAmount_returnsFixedAmountPolicy() {
+            // Given
+            DiscountMethod discountMethod = new DiscountMethod(BigDecimal.valueOf(1000));
+
+            // When
+            DiscountPolicy policy = discountMethod.toPolicy();
+
+            // Then
+            assertThat(policy).isInstanceOf(FixedAmountPolicy.class);
+        }
+
+        @Test
+        void toPolicy_withRate_returnsRatePolicy() {
+            // Given
+            DiscountMethod discountMethod = new DiscountMethod(0.1);
+
+            // When
+            DiscountPolicy policy = discountMethod.toPolicy();
+
+            // Then
+            assertThat(policy).isInstanceOf(RatePolicy.class);
+        }
+
+        @Test
+        void toPolicy_withFixedAmountTypeAndNullAmount_throwsException() {
+            // Given
+            DiscountMethod discountMethod = new DiscountMethod(BigDecimal.valueOf(1000));
+            ReflectionTestUtils.setField(discountMethod, "amount", null);
+
+            // When & Then
+            assertThrows(IllegalArgumentException.class, discountMethod::toPolicy);
+        }
+
+        @Test
+        void toPolicy_withRateTypeAndNullRate_throwsException() {
+            // Given
+            DiscountMethod discountMethod = new DiscountMethod(0.5);
+            ReflectionTestUtils.setField(discountMethod, "rate", null);
+
+            // When & Then
+            assertThrows(IllegalArgumentException.class, discountMethod::toPolicy);
+        }
+
+        @Test
+        void toPolicy_withUnknownType_throwsException() {
+            // Given
+            DiscountMethod discountMethod = new DiscountMethod(BigDecimal.TEN); // 정상 객체 생성
+            ReflectionTestUtils.setField(discountMethod, "discountType", null);
+
+            // When & Then
+            assertThrows(IllegalStateException.class, discountMethod::toPolicy);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/FixedAmountPolicyTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/FixedAmountPolicyTest.java
@@ -1,0 +1,56 @@
+package com.loopers.domain.coupon;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class FixedAmountPolicyTest {
+
+    @Nested
+    class Create {
+
+        @Test
+        void throwsException_whenAmountIsNegative() {
+            assertThrows(
+                IllegalArgumentException.class,
+                () -> new FixedAmountPolicy(BigDecimal.valueOf(-100))
+            );
+        }
+
+        @Test
+        void create_withValidAmount() {
+            FixedAmountPolicy policy = new FixedAmountPolicy(BigDecimal.valueOf(1000));
+
+            assertEquals(BigDecimal.valueOf(1000), policy.amount());
+        }
+    }
+
+    @Nested
+    class ApplyDiscount {
+
+        @Test
+        void applyDiscount_returnsZero_whenOriginalPriceIsLessThanAmount() {
+            FixedAmountPolicy policy = new FixedAmountPolicy(BigDecimal.valueOf(1000));
+            BigDecimal originalPrice = BigDecimal.valueOf(500);
+
+            BigDecimal discountedPrice = policy.applyDiscount(originalPrice);
+
+            assertEquals(BigDecimal.ZERO, discountedPrice);
+        }
+
+        @Test
+        void applyDiscount_returnsCorrectValue_whenOriginalPriceIsGreaterThanAmount() {
+            FixedAmountPolicy policy = new FixedAmountPolicy(BigDecimal.valueOf(500));
+            BigDecimal originalPrice = BigDecimal.valueOf(2000);
+
+            BigDecimal discountedPrice = policy.applyDiscount(originalPrice);
+
+            assertEquals(BigDecimal.valueOf(1500), discountedPrice);
+        }
+
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/RatePolicyTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/RatePolicyTest.java
@@ -1,0 +1,74 @@
+package com.loopers.domain.coupon;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class RatePolicyTest {
+
+    @Nested
+    class Create {
+
+        @Test
+        void throwsException_whenRateIsNegative() {
+            assertThrows(
+                IllegalArgumentException.class,
+                () -> new RatePolicy(-0.1)
+            );
+        }
+
+        @Test
+        void throwsException_whenRateIsOverOne() {
+            assertThrows(
+                IllegalArgumentException.class,
+                () -> new RatePolicy(1.1)
+            );
+        }
+
+        @Test
+        void create_withValidRate() {
+            RatePolicy policy = new RatePolicy(0.2);
+
+            assertEquals(0.2, policy.rate());
+        }
+    }
+
+    @Nested
+    class ApplyDiscount {
+
+        @Test
+        void throwsException_whenOriginalPriceIsNegative() {
+            RatePolicy policy = new RatePolicy(0.2);
+            BigDecimal originalPrice = BigDecimal.valueOf(-100);
+
+            assertThrows(
+                IllegalArgumentException.class,
+                () -> policy.applyDiscount(originalPrice)
+            );
+        }
+
+        @Test
+        void applyDiscount_returnsZero_whenOriginalPriceIsZero() {
+            RatePolicy policy = new RatePolicy(0.2);
+            BigDecimal originalPrice = BigDecimal.ZERO;
+
+            BigDecimal discountedPrice = policy.applyDiscount(originalPrice);
+
+            assertEquals(BigDecimal.ZERO, discountedPrice);
+        }
+
+        @Test
+        void applyDiscount_returnsCorrectValue_whenOriginalPriceIsPositive() {
+            RatePolicy policy = new RatePolicy(0.2);
+            BigDecimal originalPrice = BigDecimal.valueOf(1000);
+
+            BigDecimal discountedPrice = policy.applyDiscount(originalPrice);
+
+            assertEquals(BigDecimal.valueOf(800), discountedPrice);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeServiceTest.java
@@ -64,7 +64,7 @@ class LikeServiceTest {
         LikeModel like = mock(LikeModel.class);
         when(member.getId()).thenReturn(1L);
         when(product.getId()).thenReturn(2L);
-        when(likeRepository.find(1L, 2L)).thenReturn(Optional.of(like));
+        when(likeRepository.findWithLock(1L, 2L)).thenReturn(Optional.of(like));
 
         likeService.unlike(member, product);
 
@@ -75,9 +75,7 @@ class LikeServiceTest {
     void unlike_좋아요없으면_delete_호출안함() {
         MemberModel member = mock(MemberModel.class);
         ProductModel product = mock(ProductModel.class);
-        when(member.getId()).thenReturn(1L);
-        when(product.getId()).thenReturn(2L);
-        when(likeRepository.find(1L, 2L)).thenReturn(Optional.empty());
+        when(likeRepository.findWithLock(any(), any())).thenReturn(Optional.empty());
 
         likeService.unlike(member, product);
 

--- a/apps/commerce-api/src/test/java/com/loopers/domain/orders/OrderServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/orders/OrderServiceTest.java
@@ -58,7 +58,6 @@ class OrderServiceTest {
 
             assertThat(result).isNotNull();
             verify(orderRepository).save(any(OrdersModel.class));
-            verify(orderRepository).saveAll(any());
         }
 
         @Test

--- a/apps/commerce-api/src/test/java/com/loopers/domain/orders/OrderServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/orders/OrderServiceTest.java
@@ -54,7 +54,7 @@ class OrderServiceTest {
 
             when(orderRepository.save(any(OrdersModel.class))).thenReturn(order);
 
-            OrdersModel result = orderService.order(member, products);
+            OrdersModel result = orderService.order(member, products, null);
 
             assertThat(result).isNotNull();
             verify(orderRepository).save(any(OrdersModel.class));
@@ -65,7 +65,7 @@ class OrderServiceTest {
         @DisplayName("member가 null이면 BAD_REQUEST 예외 발생")
         void order_memberNull_throwsException() {
             List<Pair<ProductModel, Long>> products = List.of();
-            CoreException ex = assertThrows(CoreException.class, () -> orderService.order(null, products));
+            CoreException ex = assertThrows(CoreException.class, () -> orderService.order(null, products, null));
             assertThat(ex.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
         }
 
@@ -73,7 +73,7 @@ class OrderServiceTest {
         @DisplayName("products가 null이면 BAD_REQUEST 예외 발생")
         void order_productsNull_throwsException() {
             MemberModel member = new MemberModel("user1", Gender.FEMALE, "2000-01-01", "test@test.com", 1000L);
-            CoreException ex = assertThrows(CoreException.class, () -> orderService.order(member, null));
+            CoreException ex = assertThrows(CoreException.class, () -> orderService.order(member, null, null));
             assertThat(ex.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
         }
 
@@ -81,7 +81,7 @@ class OrderServiceTest {
         @DisplayName("products가 비어있으면 BAD_REQUEST 예외 발생")
         void order_productsEmpty_throwsException() {
             MemberModel member = new MemberModel("user1", Gender.FEMALE, "2000-01-01", "test@test.com", 1000L);
-            CoreException ex = assertThrows(CoreException.class, () -> orderService.order(member, Collections.emptyList()));
+            CoreException ex = assertThrows(CoreException.class, () -> orderService.order(member, Collections.emptyList(), null));
             assertThat(ex.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
         }
 
@@ -93,7 +93,7 @@ class OrderServiceTest {
             ProductModel product = new ProductModel("p1", com.loopers.domain.product.vo.Price.ZERO, Stock.of(1568), 369L);
             ReflectionTestUtils.setField(product, "id", 123L);
             List<Pair<ProductModel, Long>> products = List.of(Pair.of(product, 0L));
-            CoreException ex = assertThrows(CoreException.class, () -> orderService.order(member, products));
+            CoreException ex = assertThrows(CoreException.class, () -> orderService.order(member, products, null));
             assertThat(ex.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
         }
     }

--- a/http/commerce-api/example-v1.http
+++ b/http/commerce-api/example-v1.http
@@ -1,2 +1,104 @@
-### 예시 조회
-GET {{commerce-api}}/api/v1/examples/1
+### =======================================
+### Member API
+### =======================================
+
+### 회원 가입
+POST {{commerce-api}}/api/v1/users
+Content-Type: application/json
+
+{
+  "userId": "tester",
+  "gender": "MALE",
+  "birthdate": "2000-01-01",
+  "email": "tester@example.com"
+}
+
+### 내 정보 조회
+GET {{commerce-api}}/api/v1/users/me
+X-USER-ID: tester
+
+### =======================================
+### Points API
+### =======================================
+
+### 포인트 충전
+POST {{commerce-api}}/api/v1/points/charge
+Content-Type: application/json
+X-USER-ID: tester
+
+{
+  "amount": 10000
+}
+
+### 보유 포인트 조회
+GET {{commerce-api}}/api/v1/points
+X-USER-ID: tester
+
+
+### =======================================
+### Brand API
+### =======================================
+
+### 브랜드 정보 조회
+GET {{commerce-api}}/api/v1/brands/1
+
+
+### =======================================
+### Product API
+### =======================================
+
+### 상품 목록 조회
+GET {{commerce-api}}/api/v1/products?brandId=1&sort=price_asc&page=0&size=3
+
+### 상품 정보 조회
+GET {{commerce-api}}/api/v1/products/1
+
+
+### =======================================
+### Like API
+### =======================================
+
+### 상품 좋아요 등록
+POST {{commerce-api}}/api/v1/like/products/1
+X-USER-ID: tester
+
+### 상품 좋아요 취소
+DELETE {{commerce-api}}/api/v1/like/products/1
+X-USER-ID: tester
+
+### 내가 좋아요한 상품 목록 조회
+GET {{commerce-api}}/api/v1/like/products?page=0&size=3
+X-USER-ID: tester
+
+
+### =======================================
+### Order API
+### =======================================
+
+### 주문 생성
+POST {{commerce-api}}/api/v1/orders
+Content-Type: application/json
+X-USER-ID: tester
+
+{
+  "items": [
+    {
+      "productId": 1,
+      "quantity": 2
+    },
+    {
+      "productId": 3,
+      "quantity": 1
+    }
+  ],
+  "couponId": 1
+}
+
+### 내 주문 목록 조회
+GET {{commerce-api}}/api/v1/orders
+X-USER-ID: tester
+
+### 주문 상세 조회
+GET {{commerce-api}}/api/v1/orders/1
+X-USER-ID: tester
+


### PR DESCRIPTION
## 📌 Summary

주문, 쿠폰, 좋아요 기능에 대한 동시성 테스트 및 락 적용
쿠폰 도메인 설계 및 기능 추가
미비한 구현 보강 

## 💬 Review Points

1. 조회 기능에 사용되는 sort 파라미터 관리를 어떻게 하시나요? 의사 코드로 보여주실 수 있나요?
저는 domain/product 에서 처럼  order by 를 열거형으로 선언해 봤는데, sort 파라미터는 조회 기능에 따라 여러 값이 나올 수 있다고
생각합니다. 그래서 조회 기능마다 order by를 만드는 선택지가 있을 것 같고, 아니면 해당 도메인 안에서 쓰이는 모든 sort 값을 나열한 enum을 하나만 둘 수 도 있을 것 같습니다. 또한 ProductV1Controller 작성할 때 문자열로 입력받은 sort 필드를 Sort 객체로 변환하는 private method를 두었는데 이는 객체지향적으로 안 좋은 코드일까요? 어떻게 개선해볼 여지가 있는지 궁금합니다. 

2. 컨트롤러 레벨 요청과 응답 dto 관리법 추천 및 복잡한 페이징 조회 조건을 관리/처리 어떻게 하시는지에 대한 의사 코드로 알려주실 수 있나요?
- 컨트롤러 작성 시 매번 고민되는게 네이밍 + 요청과 응답 dto 객체 관리 문제라 좋은 해결책이 있을까요?
일단 컨트롤러 메서드 하나 당 그 메서드 이름을 그대로 따라가되 postfix로 Request / Response를 붙여보고 있기는 한데, 
컨트롤러의 코드 베이스가 커지면 커질수록 하나의 DTO 클래스 파일 안에 너무 많은  nested class/record가 존재하게 되면 관리가 어려울 것 같습니다. 혹시 멘토님만의 다른 관리 방식이 있는지와 DTO 클래스 파일을 중간에 쪼개기도 하는지도 궁금합니다.
- 그리고 요청/응답 dto 관리도 관리지만 Rest API를 만들면서 가장 고민되는 것이 수 많은 조회 조건 argument(if 20개라면?)를 요구하는 컨트롤러가 있다면 이러한 조회 조건 인자를 어떻게 받아서 이를 어떻게 야무지게 레포지토리의 쿼리 인자로 전달 시킬 수 있을지 고민입니다.
혹시 객체지향적으로 해결해볼 부분이 있을까요? 멘토님은 컨트롤러로부터 많은 조회 조건을 전달 받아서 레포지토리에 전달하기까지의 구조를 객체지향 혹은 다른 방식으로 리팩토링/개선 시켜본 멘토님만의 방식이 있으신가요? 

3. application service 에서의 repository 사용 구조 질문
비관적 락을 걸다보니, 저의 기존 코드는 도메인 서비스에서 모든 레포지토리 호출 = 즉, 영속화 관련 책임을 수행했었습니다.
그런데 이번에 동시성 문제 해결을 위해 기존 룰을 깨고 레포지토리에 락 관련 기능을 넣은 뒤 어플리케이션 서비스에서 락 관련 영속화 관리 작업을 컨트롤하도록 작성했습니다. 이 과정에서 느낀바가, 도메인 서비스로부터 영속화 책임을 떼어내서 DB/NoSQL 등으로부터
find, save 등을 해오는 작업을 어플리케이션 서비스 레이어에서만 하는 것이 책임 구분이 명확하고 사용성이 좋지 않을까? 란 생각이 들었습니다. 영속화란 내용을 도메인 서비스로부터 분리 시키면 도메인 서비스가 더욱 비즈니스 로직에만 충실해지겠다는 생각도 들었구요.
이에 대해서 어떻게 생각하시는지 궁금합니다.

4. 저는 이번 과제에서 하나의 유즈케이스에 대한 동시성 테스트만을 해봤는데, 동시성 테스트 경험이 적어서 질문 드립니다.
혹시 여러 유즈케이스 간의 상호작용 과정에서 동시성 이슈가 발생하는지 검증을 하는 테스트 코드는 어떻게 작성해야 하나요?
간략한 의사 코드로 예시를 알려주실 수 있으신가요? "유즈케이스 간의 상호작용" 을 시나리오로 테스트 코드 상에서 표현하기 위해서는 작업 간의 순서를 이리저리 검증하고자 하는 엣지 케이스에 맞춰 조정해야 할 수 도 있을 것 같은데 동시성 + 멀티 스레드다 보니 방법을 잘 모르겠습니다. 

5. 낙관적 락과 비관적 락 코드 레벨에서의 고민
- 비관적 락을 걸면 해당 코드 라인에서 대기가 발생할텐데 그렇다면 비관적 락을 거는 코드 라인이 비관적 락이 꼭 필요한 위치의 필요한 자원에 대해서만 거는 것이 좋을까요? CommandOrderUseCase 에서 예시로 어차피 하나의 트랜잭션/기능인데 회원과 상품 각각에 대해서 락을 걸어야 하나? 메서드의 시작 부분에 쓰이는 자원(예: 회원)에 바로 락 걸고 로직 중간에 쓰이는 자원에 대해서는 락을 안거는 식으로 즉, (극단적으로는 어느 자원이든) 메서드 시작 초기에 락 걸면 동일 유즈케이스/기능에 대해서는 동시성 문제 극복이라는 효과를 동일하게 누릴 수 있겠다는 생각이 들었습니다. 
- 쿠폰에 낙관적 락을 적용한 상태입니다. CommandOrderUseCase 를 보면 원래는 코드 최상단 부분에 쿠폰 처리 로직을 둬서 쿠폰의 낙관적 락에 의한 fast fail을 시키고 싶었습니다. 그러나 쿠폰 도메인 모델 자체(apply)에 사용을 한번만 가능케 하는 제약 + 쿠폰 사용에는 상품 총액이 필요하다는 점 + 어차피 상품 총액을 구하기 위해 상품 목록을 loop 돌아야 한다면 이때 재고를 차감하는 작업을 수행하는 것이 효과적일 것 같다는 판단 = 이러한 요인들의 합작으로 인해 재고 처리 -> 쿠폰 사용 -> 포인트 차감 -> 주문 정보 저장의 순서가 생기게 됐습니다. 질문의 요지는, 주문 요청이라는 기능 내부에서 "재고 처리, 쿠폰 사용, 포인트 차감, 주문 정보 저장" 이라는 각 작업의 순서를 유연하게 배치시킬 수 있는 구조를 만들기 위해선 어떻게 코드를 개선시켜야 할지 조언 부탁 드립니다.
ex) 목표: "결제(= 쿠폰사용 + 포인트 차감) -> 재고 처리 -> 주문 저장" 또는 "재고 처리 -> 결제 -> 주문 저장" 중 개발자가 원하는 순서 결정이 가능하도록 작업 순서 간의 결합도를 낮추는 것.

## ✅ Checklist

### 🗞️ Coupon 도메인

- [ ]  쿠폰은 사용자가 소유하고 있으며, 이미 사용된 쿠폰은 사용할 수 없어야 한다.
- [ ]  쿠폰 종류는 정액 / 정률로 구분되며, 각 적용 로직을 구현하였다.
- [ ]  각 발급된 쿠폰은 최대 한번만 사용될 수 있다.

### 🧾 **주문**

- [ ]  주문 전체 흐름에 대해 원자성이 보장되어야 한다.
- [ ]  사용 불가능하거나 존재하지 않는 쿠폰일 경우 주문은 실패해야 한다.
- [ ]  재고가 존재하지 않거나 부족할 경우 주문은 실패해야 한다.
- [ ]  주문 시 유저의 포인트 잔액이 부족할 경우 주문은 실패해야 한다
- [ ]  쿠폰, 재고, 포인트 처리 등 하나라도 작업이 실패하면 모두 롤백처리되어야 한다.
- [ ]  주문 성공 시, 모든 처리는 정상 반영되어야 한다.

### 🧪 동시성 테스트

- [ ]  동일한 상품에 대해 여러명이 좋아요/싫어요를 요청해도, 상품의 좋아요 개수가 정상 반영되어야 한다.
- [ ]  동일한 쿠폰으로 여러 기기에서 동시에 주문해도, 쿠폰은 단 한번만 사용되어야 한다.
- [ ]  동일한 유저가 서로 다른 주문을 동시에 수행해도, 포인트가 정상적으로 차감되어야 한다.
- [ ]  동일한 상품에 대해 여러 주문이 동시에 요청되어도, 재고가 정상적으로 차감되어야 한다.