### PR TITLE
[round 6] Failure-Ready Systems

### DIFF
--- a/apps/commerce-api/build.gradle.kts
+++ b/apps/commerce-api/build.gradle.kts
@@ -11,6 +11,13 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:${project.properties["springDocOpenApiVersion"]}")
 
+    // Feign
+    implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
+
+    // Resilience4j - Feign 통합을 위한 라이브러리
+    implementation("org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j")
+    implementation("io.github.resilience4j:resilience4j-feign:2.2.0")
+
     // querydsl
     annotationProcessor("com.querydsl:querydsl-apt::jakarta")
     annotationProcessor("jakarta.persistence:jakarta.persistence-api")

--- a/apps/commerce-api/src/main/java/com/loopers/CommerceApiApplication.java
+++ b/apps/commerce-api/src/main/java/com/loopers/CommerceApiApplication.java
@@ -4,7 +4,9 @@ import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 import java.util.TimeZone;
 
@@ -13,6 +15,8 @@ import static org.springframework.data.web.config.EnableSpringDataWebSupport.Pag
 @ConfigurationPropertiesScan
 @SpringBootApplication
 @EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO)
+@EnableFeignClients
+@EnableScheduling
 public class CommerceApiApplication {
 
     public static void main(String[] args) {

--- a/apps/commerce-api/src/main/java/com/loopers/application/orders/dto/CardInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/orders/dto/CardInfo.java
@@ -1,0 +1,31 @@
+package com.loopers.application.orders.dto;
+
+import com.loopers.domain.payment.CardType;
+
+public record CardInfo(
+    CardTypeInfo cardTypeInfo,
+    String cardNumber
+) {
+    public enum CardTypeInfo {
+        SAMSUNG,
+        KB,
+        HYUNDAI;
+
+        public static CardTypeInfo from(CardType cardType) {
+            return switch (cardType) {
+                case SAMSUNG -> SAMSUNG;
+                case KB -> KB;
+                case HYUNDAI -> HYUNDAI;
+                default -> throw new IllegalArgumentException("Unknown card type: " + cardType);
+            };
+        }
+
+        public CardType toCardType() {
+            return switch (this) {
+                case SAMSUNG -> CardType.SAMSUNG;
+                case KB -> CardType.KB;
+                case HYUNDAI -> CardType.HYUNDAI;
+            };
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentFacade.java
@@ -1,0 +1,94 @@
+package com.loopers.application.payment;
+
+import com.loopers.application.payment.dto.PaymentOrder;
+import com.loopers.application.payment.dto.PaymentOrderResult;
+import com.loopers.application.payment.dto.SyncPaymentCommand;
+import com.loopers.domain.member.MemberModel;
+import com.loopers.domain.member.MemberRepository;
+import com.loopers.domain.orders.OrderRepository;
+import com.loopers.domain.orders.OrderResourceManager;
+import com.loopers.domain.orders.OrdersModel;
+import com.loopers.domain.payment.*;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PaymentFacade {
+    private final PaymentProcessor<CardPaymentRequest> cardPaymentProcessor;
+    private final PaymentProcessor<PointPaymentRequest> pointPaymentProcessor;
+    private final PgProvider<CardPaymentRequest> pgProvider;
+    private final MemberRepository memberRepository;
+    private final OrderRepository orderRepository;
+    private final PaymentRepository paymentRepository;
+    private final OrderResourceManager orderResourceManager;
+
+    public PaymentOrderResult requestPayment(PaymentOrder request) {
+        MemberModel member = memberRepository.findByUserId(request.userId()).orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND));
+        OrdersModel order = orderRepository.find(request.orderId()).orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND));
+        switch (request.paymentMethod()) {
+            case CARD -> {
+                PaymentModel paymentModel = cardPaymentProcessor.pay(new CardPaymentRequest(member, order, request.amount(), request.cardType().toDomain(), request.cardNo()));
+                return new PaymentOrderResult(paymentModel.getTransactionKey());
+            }
+            case POINTS -> {
+                PaymentModel paymentModel = pointPaymentProcessor.pay(new PointPaymentRequest(member, order, request.amount()));
+                if (paymentModel.getStatus() == TransactionStatus.SUCCESS) {
+                    order.process();
+                    orderRepository.save(order);
+                }
+                return new PaymentOrderResult(paymentModel.getTransactionKey());
+            }
+            default -> {
+                log.error("Unsupported payment method: {}", request.paymentMethod());
+                throw new CoreException(ErrorType.BAD_REQUEST, "Unsupported payment method: " + request.paymentMethod());
+            }
+        }
+    }
+
+    @Transactional
+    public void syncPayment(SyncPaymentCommand command) {
+        PaymentModel payment = paymentRepository.findByTxKey(command.transactionKey())
+            .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "Payment not found for transaction key: " + command.transactionKey()));
+        OrdersModel order = orderRepository.find(Long.valueOf(payment.getOrderId()))
+            .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "Order not found for ID: " + payment.getOrderId()));
+
+        if (payment.getStatus() != TransactionStatus.PENDING) {
+            log.warn("Payment already processed or not in pending state: {}", payment.getStatus());
+            throw new CoreException(ErrorType.BAD_REQUEST, "Payment already processed or not in pending state.");
+        }
+
+        var detail = pgProvider.getTransactionDetail(payment.getUserId(), command.transactionKey());
+        if (detail.status() != command.status().toDomain()) {
+            log.error("Payment status mismatch: expected {}, got {}", command.status(), detail.status());
+            throw new CoreException(ErrorType.BAD_REQUEST, "Payment status mismatch.");
+        }
+
+        var transactions = pgProvider.getTransactionsByOrder(payment.getUserId(), payment.getOrderId());
+        if (transactions.transactions().stream().filter(t -> t.status() == TransactionStatus.SUCCESS).count() > 1) {
+            log.error("Multiple successful transactions found for order: {}", command.orderId());
+            throw new CoreException(ErrorType.BAD_REQUEST, "Multiple successful transactions found for order.");
+        }
+
+        switch (detail.status()) {
+            case SUCCESS -> {
+                payment.approve();
+                paymentRepository.save(payment);
+                order.process();
+                orderRepository.save(order);
+            }
+            case FAILED -> {
+                payment.failed(detail.reason());
+                paymentRepository.save(payment);
+                orderResourceManager.restoreResources(order);
+            }
+        }
+    }
+
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentScheduler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentScheduler.java
@@ -1,0 +1,57 @@
+package com.loopers.application.payment;
+
+import com.loopers.domain.orders.OrderRepository;
+import com.loopers.domain.orders.OrderResourceManager;
+import com.loopers.domain.orders.OrdersModel;
+import com.loopers.domain.payment.*;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class PaymentScheduler {
+
+    private final PaymentRepository paymentRepository;
+    private final PgProvider<CardPaymentRequest> pgProvider;
+    private final OrderResourceManager orderResourceManager;
+    private final OrderRepository orderRepository;
+
+    @Scheduled(fixedRate = 600000) // 10분마다 실행
+    public void checkPendingPayments() {
+        ZonedDateTime threshold = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).minusMinutes(10);
+        List<PaymentModel> oldPendingPayments = paymentRepository.findAllPendingOlderThan(TransactionStatus.PENDING, threshold);
+        for (PaymentModel payment : oldPendingPayments) {
+            var detail = pgProvider.getTransactionDetail(payment.getUserId(), payment.getTransactionKey());
+            if (detail == null) {
+                log.warn("No transaction detail found for payment: {}", payment.getTransactionKey());
+                continue; // 상세 정보가 없는 경우, 다음 결제 확인으로 넘어감
+            }
+
+            OrdersModel order = orderRepository.find(Long.valueOf(payment.getOrderId()))
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "Order not found for ID: " + payment.getOrderId()));
+
+            switch (detail.status()) {
+                case SUCCESS -> {
+                    payment.approve();
+                    paymentRepository.save(payment);
+                    order.process();
+                    orderRepository.save(order);
+                }
+                case FAILED -> {
+                    payment.failed(detail.reason());
+                    paymentRepository.save(payment);
+                    orderResourceManager.restoreResources(order);
+                }
+            }
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/dto/PaymentOrder.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/dto/PaymentOrder.java
@@ -1,0 +1,33 @@
+package com.loopers.application.payment.dto;
+
+import com.loopers.domain.payment.CardType;
+
+import java.math.BigDecimal;
+
+public record PaymentOrder(
+    PaymentMethod paymentMethod,
+    String userId,
+    Long orderId,
+    BigDecimal amount,
+    CardTypeInfo cardType,
+    String cardNo
+) {
+    public enum CardTypeInfo {
+        SAMSUNG,
+        KB,
+        HYUNDAI;
+
+        public CardType toDomain() {
+            return switch (this) {
+                case SAMSUNG -> CardType.SAMSUNG;
+                case KB -> CardType.KB;
+                case HYUNDAI -> CardType.HYUNDAI;
+            };
+        }
+    }
+
+    public enum PaymentMethod {
+        CARD,
+        POINTS
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/dto/PaymentOrderResult.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/dto/PaymentOrderResult.java
@@ -1,0 +1,4 @@
+package com.loopers.application.payment.dto;
+
+public record PaymentOrderResult(String transactionKey) {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/dto/SyncPaymentCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/dto/SyncPaymentCommand.java
@@ -1,0 +1,42 @@
+package com.loopers.application.payment.dto;
+
+import com.loopers.domain.payment.CardType;
+import com.loopers.domain.payment.TransactionStatus;
+
+public record SyncPaymentCommand(
+    String transactionKey,
+    String orderId,
+    CardTypeInfo cardType,
+    String cardNo,
+    Long amount,
+    TransactionStatusInfo status,
+    String reason
+) {
+    public enum CardTypeInfo {
+        SAMSUNG,
+        KB,
+        HYUNDAI;
+
+        public CardType toDomain() {
+            return switch (this) {
+                case SAMSUNG -> CardType.SAMSUNG;
+                case KB -> CardType.KB;
+                case HYUNDAI -> CardType.HYUNDAI;
+            };
+        }
+    }
+
+    public enum TransactionStatusInfo {
+        PENDING,
+        SUCCESS,
+        FAILED;
+
+        public TransactionStatus toDomain() {
+            return switch (this) {
+                case PENDING -> TransactionStatus.PENDING;
+                case SUCCESS -> TransactionStatus.SUCCESS;
+                case FAILED -> TransactionStatus.FAILED;
+            };
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/orders/OrderCouponManager.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/orders/OrderCouponManager.java
@@ -1,0 +1,11 @@
+package com.loopers.domain.orders;
+
+import com.loopers.domain.coupon.CouponModel;
+
+import java.util.Optional;
+
+public interface OrderCouponManager {
+    Optional<CouponModel> find(Long id);
+
+    void saveAndFlush(CouponModel couponModel);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/orders/OrderResourceManager.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/orders/OrderResourceManager.java
@@ -1,0 +1,28 @@
+package com.loopers.domain.orders;
+
+import com.loopers.domain.coupon.CouponModel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class OrderResourceManager {
+
+    private final OrderCouponManager orderCouponManager;
+    private final ProductStockManager productStockManager;
+
+    @Transactional
+    public void restoreResources(OrdersModel order) {
+        if (order.getCouponId() != null) {
+            CouponModel couponModel = orderCouponManager.find(order.getCouponId())
+                .orElseThrow(() -> new IllegalArgumentException("Coupon not found for ID: " + order.getCouponId()));
+            couponModel.restore();
+            orderCouponManager.saveAndFlush(couponModel);
+        }
+
+        if (order.getItems() != null && !order.getItems().isEmpty()) {
+            productStockManager.restoreAllStock(order.getItems());
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/orders/OrderService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/orders/OrderService.java
@@ -10,7 +10,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Component;
 
-import java.math.BigDecimal;
 import java.util.List;
 
 @Component
@@ -19,14 +18,14 @@ public class OrderService {
 
     private final OrderRepository orderRepository;
 
-    public OrdersModel order(MemberModel member, List<Pair<ProductModel, Long>> products, Long couponId) {
+    public OrdersModel order(MemberModel member, List<Pair<ProductModel, Long>> products, Long couponId, Price totalPrice) {
         if (member == null || products == null || products.isEmpty()) {
             throw new CoreException(ErrorType.BAD_REQUEST, "Member and Products cannot be null or empty.");
         }
 
-        Price totalPrice = Price.of(products.stream()
-            .map(pair -> pair.getFirst().getPrice().multiply(pair.getSecond()).getAmount())
-            .reduce(BigDecimal.ZERO, BigDecimal::add));
+//        Price totalPrice = Price.of(products.stream()
+//            .map(pair -> pair.getFirst().getPrice().multiply(pair.getSecond()).getAmount())
+//            .reduce(BigDecimal.ZERO, BigDecimal::add));
 
         OrdersModel order = new OrdersModel(member.getId(), totalPrice, couponId);
         OrdersModel savedOrder = orderRepository.save(order);

--- a/apps/commerce-api/src/main/java/com/loopers/domain/orders/OrdersModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/orders/OrdersModel.java
@@ -66,4 +66,11 @@ public class OrdersModel extends BaseEntity {
         }
         this.status = OrderStatus.PAID;
     }
+
+    public void cancel() {
+        if (this.status != OrderStatus.NOT_PAID) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "Invalid order status");
+        }
+        this.status = OrderStatus.CANCELED;
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/orders/ProductStockManager.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/orders/ProductStockManager.java
@@ -1,0 +1,7 @@
+package com.loopers.domain.orders;
+
+import java.util.Set;
+
+public interface ProductStockManager {
+    void restoreAllStock(Set<OrderItemModel> items);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/CardPaymentProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/CardPaymentProcessor.java
@@ -1,0 +1,33 @@
+package com.loopers.domain.payment;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CardPaymentProcessor implements PaymentProcessor<CardPaymentRequest> {
+
+    private final PaymentRepository paymentRepository;
+    private final PgProvider<CardPaymentRequest> pgProvider;
+
+    @Override
+    public boolean supports(PaymentType type) {
+        return type == PaymentType.CARD;
+    }
+
+    @Override
+    public PaymentModel pay(CardPaymentRequest request) {
+        var result = pgProvider.requestTransaction(request);
+        System.out.println("CardPaymentProcessor.pay() - result: " + result);
+
+        PaymentModel paymentModel = PaymentModel.createCardPayment(
+            result.transactionKey(),
+            request.getMember().getUserId(),
+            request.getOrder().getId().toString(),
+            request.getCardType(),
+            request.getCardNo(),
+            request.getAmount()
+        );
+        return paymentRepository.save(paymentModel);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/CardPaymentRequest.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/CardPaymentRequest.java
@@ -1,0 +1,28 @@
+package com.loopers.domain.payment;
+
+import com.loopers.domain.member.MemberModel;
+import com.loopers.domain.orders.OrdersModel;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+public class CardPaymentRequest extends PaymentRequest {
+    @Getter
+    private final CardType cardType;
+
+    @Getter
+    private final String cardNo;
+
+    public CardPaymentRequest(
+        MemberModel member,
+        OrdersModel order,
+        BigDecimal amount,
+        CardType cardType,
+        String cardNo
+
+    ) {
+        super(PaymentType.CARD, member, order, amount);
+        this.cardType = cardType;
+        this.cardNo = cardNo;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/CardType.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/CardType.java
@@ -1,0 +1,7 @@
+package com.loopers.domain.payment;
+
+public enum CardType {
+    SAMSUNG,
+    KB,
+    HYUNDAI,
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/OrderResult.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/OrderResult.java
@@ -1,0 +1,10 @@
+package com.loopers.domain.payment;
+
+
+import java.util.List;
+
+public record OrderResult(
+    String orderId,
+    List<TransactionResult> transactions
+) {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentModel.java
@@ -1,0 +1,128 @@
+package com.loopers.domain.payment;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "payment")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PaymentModel extends BaseEntity {
+    @Column(name = "transaction_key", nullable = false, unique = true)
+    @Getter
+    String transactionKey;
+
+    @Column(name = "user_id", nullable = false)
+    @Getter
+    String userId;
+
+    @Column(name = "order_id", nullable = false)
+    @Getter
+    String orderId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "payment_type", nullable = false)
+    PaymentType paymentType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "card_type")
+    CardType cardType;
+
+    @Column(name = "card_no")
+    String cardNo;
+
+    @Column(name = "amount", nullable = false)
+    BigDecimal amount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    @Getter
+    TransactionStatus status = TransactionStatus.PENDING;
+
+    @Column(name = "reason")
+    String reason = null;
+
+    private PaymentModel(
+        String transactionKey,
+        String userId,
+        String orderId,
+        PaymentType paymentType,
+        CardType cardType,
+        String cardNo,
+        BigDecimal amount,
+        TransactionStatus status,
+        String reason
+    ) {
+        this.transactionKey = transactionKey;
+        this.userId = userId;
+        this.orderId = orderId;
+        this.paymentType = paymentType;
+        this.cardType = cardType;
+        this.cardNo = cardNo;
+        this.amount = amount;
+        this.status = status;
+        this.reason = reason;
+    }
+
+    public static PaymentModel createCardPayment(
+        String transactionKey,
+        String userId,
+        String orderId,
+        CardType cardType,
+        String cardNo,
+        BigDecimal amount
+    ) {
+        return new PaymentModel(
+            transactionKey,
+            userId,
+            orderId,
+            PaymentType.CARD,
+            cardType,
+            cardNo,
+            amount,
+            TransactionStatus.PENDING,
+            null
+        );
+    }
+
+    public static PaymentModel createPointPayment(
+        String transactionKey,
+        String userId,
+        String orderId,
+        BigDecimal amount
+    ) {
+        return new PaymentModel(
+            transactionKey,
+            userId,
+            orderId,
+            PaymentType.POINTS,
+            null,
+            null,
+            amount,
+            TransactionStatus.PENDING,
+            null
+        );
+    }
+
+    public void approve() {
+        if (status != TransactionStatus.PENDING) {
+            throw new CoreException(ErrorType.INTERNAL_ERROR, "결제승인은 대기상태에서만 가능합니다.");
+        }
+        this.status = TransactionStatus.SUCCESS;
+        this.reason = "정상 승인되었습니다.";
+    }
+
+    public void failed(String reason) {
+        if (status != TransactionStatus.PENDING) {
+            throw new CoreException(ErrorType.INTERNAL_ERROR, "결제실패는 대기상태에서만 가능합니다.");
+        }
+        this.status = TransactionStatus.FAILED;
+        this.reason = reason != null ? reason : "결제에 실패했습니다. 다시 시도해주세요.";
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentProcessor.java
@@ -1,0 +1,7 @@
+package com.loopers.domain.payment;
+
+public interface PaymentProcessor<T extends PaymentRequest> {
+    boolean supports(PaymentType type);
+
+    PaymentModel pay(T request);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentRepository.java
@@ -1,0 +1,15 @@
+package com.loopers.domain.payment;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface PaymentRepository {
+    PaymentModel save(PaymentModel payment);
+
+    Optional<PaymentModel> findByTxKey(String transactionKey);
+
+    List<PaymentModel> findAllByOrderId(String orderId);
+
+    List<PaymentModel> findAllPendingOlderThan(TransactionStatus status, ZonedDateTime threshold);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentRequest.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentRequest.java
@@ -1,0 +1,41 @@
+package com.loopers.domain.payment;
+
+import com.loopers.domain.member.MemberModel;
+import com.loopers.domain.orders.OrdersModel;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+public abstract class PaymentRequest {
+    @Getter
+    private PaymentType paymentType;
+
+    @Getter
+    private MemberModel member;
+
+    @Getter
+    private OrdersModel order;
+
+    @Getter
+    private BigDecimal amount;
+
+
+    public PaymentRequest(PaymentType paymentType, MemberModel member, OrdersModel order, BigDecimal amount) {
+        if (paymentType == null) {
+            throw new IllegalArgumentException("Payment type cannot be null");
+        }
+        if (member == null) {
+            throw new IllegalArgumentException("User ID cannot be null or blank");
+        }
+        if (order == null) {
+            throw new IllegalArgumentException("Order ID cannot be null or blank");
+        }
+        if (amount == null || amount.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("Amount must be a positive number");
+        }
+        this.paymentType = paymentType;
+        this.member = member;
+        this.order = order;
+        this.amount = amount;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentType.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentType.java
@@ -1,0 +1,6 @@
+package com.loopers.domain.payment;
+
+public enum PaymentType {
+    CARD,
+    POINTS
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PgProvider.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PgProvider.java
@@ -1,0 +1,9 @@
+package com.loopers.domain.payment;
+
+public interface PgProvider<T extends PaymentRequest> {
+    TransactionResult requestTransaction(T request);
+
+    TransactionDetailResult getTransactionDetail(String userId, String transactionKey);
+
+    OrderResult getTransactionsByOrder(String userId, String orderId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PointManager.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PointManager.java
@@ -1,0 +1,7 @@
+package com.loopers.domain.payment;
+
+import com.loopers.domain.member.MemberModel;
+
+public interface PointManager {
+    void updateMemberPoints(MemberModel member);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PointPaymentProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PointPaymentProcessor.java
@@ -1,0 +1,47 @@
+package com.loopers.domain.payment;
+
+import com.loopers.domain.member.MemberModel;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class PointPaymentProcessor implements PaymentProcessor<PointPaymentRequest> {
+
+    private final PointManager pointManager;
+    private final PaymentRepository paymentRepository;
+
+    @Override
+    public boolean supports(PaymentType type) {
+        return type == PaymentType.POINTS;
+    }
+
+    @Transactional
+    @Override
+    public PaymentModel pay(PointPaymentRequest request) {
+        MemberModel member = request.getMember();
+        PaymentModel paymentModel = PaymentModel.createPointPayment(
+            UUID.randomUUID().toString().replace("-", "").substring(0, 6),
+            request.getMember().getUserId(),
+            request.getOrder().getId().toString(),
+            request.getAmount()
+        );
+
+        try {
+            member.usePoints(request.getAmount().longValue());
+        } catch (CoreException e) {
+            if (e.getErrorType() != ErrorType.CONFLICT) {
+                throw e;
+            }
+            paymentModel.failed(e.getMessage());
+        }
+        pointManager.updateMemberPoints(member);
+        paymentModel.approve();
+        return paymentRepository.save(paymentModel);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PointPaymentRequest.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PointPaymentRequest.java
@@ -1,0 +1,16 @@
+package com.loopers.domain.payment;
+
+import com.loopers.domain.member.MemberModel;
+import com.loopers.domain.orders.OrdersModel;
+
+import java.math.BigDecimal;
+
+public class PointPaymentRequest extends PaymentRequest {
+    public PointPaymentRequest(
+        MemberModel member,
+        OrdersModel order,
+        BigDecimal amount
+    ) {
+        super(PaymentType.POINTS, member, order, amount);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/TransactionDetailResult.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/TransactionDetailResult.java
@@ -1,0 +1,14 @@
+package com.loopers.domain.payment;
+
+import java.math.BigDecimal;
+
+public record TransactionDetailResult(
+    String transactionKey,
+    String orderId,
+    CardType cardType,
+    String cardNo,
+    BigDecimal amount,
+    TransactionStatus status,
+    String reason
+) {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/TransactionResult.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/TransactionResult.java
@@ -1,0 +1,4 @@
+package com.loopers.domain.payment;
+
+public record TransactionResult(String transactionKey, TransactionStatus status, String reason) {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/TransactionStatus.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/TransactionStatus.java
@@ -1,0 +1,7 @@
+package com.loopers.domain.payment;
+
+public enum TransactionStatus {
+    PENDING,
+    SUCCESS,
+    FAILED
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductModel.java
@@ -72,4 +72,8 @@ public class ProductModel extends BaseEntity {
         }
         this.likeCount = likeCount;
     }
+
+    public void restoreStock(long quantity) {
+        this.stock = this.stock.restore(quantity);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/vo/Stock.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/vo/Stock.java
@@ -40,6 +40,13 @@ public class Stock implements Serializable {
         return new Stock(this.quantity - quantity);
     }
 
+    public Stock restore(long quantity) {
+        if (quantity < 0) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "복구할 재고 수량은 음수일 수 없습니다.");
+        }
+        return new Stock(this.quantity + quantity);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (o == null || getClass() != o.getClass()) return false;

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.loopers.infrastructure.coupon;
 
 import com.loopers.domain.coupon.CouponModel;
 import com.loopers.domain.coupon.CouponRepository;
+import com.loopers.domain.orders.OrderCouponManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -9,7 +10,7 @@ import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
-public class CouponRepositoryImpl implements CouponRepository {
+public class CouponRepositoryImpl implements CouponRepository, OrderCouponManager {
 
     private final CouponJpaRepository couponJpaRepository;
 
@@ -22,4 +23,5 @@ public class CouponRepositoryImpl implements CouponRepository {
     public void saveAndFlush(CouponModel couponModel) {
         couponJpaRepository.saveAndFlush(couponModel);
     }
+    
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/member/MemberJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/member/MemberJpaRepository.java
@@ -4,6 +4,7 @@ import com.loopers.domain.member.MemberModel;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -15,4 +16,8 @@ public interface MemberJpaRepository extends JpaRepository<MemberModel, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select m from MemberModel m where m.id = :id")
     Optional<MemberModel> findWithLock(@Param("id") Long id);
+
+    @Modifying
+    @Query("update MemberModel m set m.points = :points where m.id = :id")
+    void updateMemberPoints(@Param("id") Long id, @Param("points") Long points);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/member/MemberRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/member/MemberRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.loopers.infrastructure.member;
 
 import com.loopers.domain.member.MemberModel;
 import com.loopers.domain.member.MemberRepository;
+import com.loopers.domain.payment.PointManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -9,7 +10,7 @@ import java.util.Optional;
 
 @RequiredArgsConstructor
 @Repository
-public class MemberRepositoryImpl implements MemberRepository {
+public class MemberRepositoryImpl implements MemberRepository, PointManager {
     private final MemberJpaRepository memberJpaRepository;
 
     @Override
@@ -30,5 +31,10 @@ public class MemberRepositoryImpl implements MemberRepository {
     @Override
     public Optional<MemberModel> findWithLock(Long id) {
         return memberJpaRepository.findWithLock(id);
+    }
+
+    @Override
+    public void updateMemberPoints(MemberModel member) {
+        memberJpaRepository.updateMemberPoints(member.getId(), member.getPoints());
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentJpaRepository.java
@@ -1,0 +1,23 @@
+package com.loopers.infrastructure.payment;
+
+import com.loopers.domain.payment.PaymentModel;
+import com.loopers.domain.payment.TransactionStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface PaymentJpaRepository extends JpaRepository<PaymentModel, Long> {
+    Optional<PaymentModel> findByTransactionKey(String transactionKey);
+
+    List<PaymentModel> findAllByOrderId(String orderId);
+
+    @Query("SELECT p FROM PaymentModel p WHERE p.status = :status AND p.createdAt <= :threshold")
+    List<PaymentModel> findAllPendingOlderThan(
+        @Param("status") TransactionStatus status,
+        @Param("threshold") ZonedDateTime threshold
+    );
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentRepositoryImpl.java
@@ -1,0 +1,40 @@
+package com.loopers.infrastructure.payment;
+
+import com.loopers.domain.payment.PaymentModel;
+import com.loopers.domain.payment.PaymentRepository;
+import com.loopers.domain.payment.TransactionStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class PaymentRepositoryImpl implements PaymentRepository {
+
+    private final PaymentJpaRepository paymentJpaRepository;
+
+    @Override
+    @Transactional
+    public PaymentModel save(PaymentModel paymentModel) {
+        return paymentJpaRepository.save(paymentModel);
+    }
+
+    @Override
+    public Optional<PaymentModel> findByTxKey(String transactionKey) {
+        return paymentJpaRepository.findByTransactionKey(transactionKey);
+    }
+
+    @Override
+    public List<PaymentModel> findAllByOrderId(String orderId) {
+        return paymentJpaRepository.findAllByOrderId(orderId);
+    }
+
+    @Override
+    public List<PaymentModel> findAllPendingOlderThan(TransactionStatus status, ZonedDateTime threshold) {
+        return paymentJpaRepository.findAllPendingOlderThan(status, threshold);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/pg/OrderKeyEncoder.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/pg/OrderKeyEncoder.java
@@ -1,0 +1,26 @@
+package com.loopers.infrastructure.pg;
+
+
+public class OrderKeyEncoder {
+    private static final String BASE62 = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+    public static String encode(Long value) {
+        StringBuilder sb = new StringBuilder();
+        while (value > 0) {
+            sb.append(BASE62.charAt((int) (value % 62)));
+            value /= 62;
+        }
+        while (sb.length() < 6) { // 최소 6자리 보장
+            sb.append('0');
+        }
+        return sb.reverse().toString();
+    }
+
+    public static Long decode(String str) {
+        long result = 0;
+        for (int i = 0; i < str.length(); i++) {
+            result = result * 62 + BASE62.indexOf(str.charAt(i));
+        }
+        return result;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/pg/OrderResponse.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/pg/OrderResponse.java
@@ -1,0 +1,22 @@
+package com.loopers.infrastructure.pg;
+
+import com.loopers.domain.payment.OrderResult;
+import com.loopers.domain.payment.TransactionResult;
+
+import java.util.List;
+
+public record OrderResponse(
+    String orderId,
+    List<TransactionResponse> transactions
+) {
+    public static OrderResult toResult(OrderResponse response) {
+        List<TransactionResult> transactionResults = response.transactions().stream()
+            .map(TransactionResponse::toResult)
+            .toList();
+
+        return new OrderResult(
+            OrderKeyEncoder.decode(response.orderId()).toString(),
+            transactionResults
+        );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/pg/PgApiResponse.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/pg/PgApiResponse.java
@@ -1,0 +1,65 @@
+package com.loopers.infrastructure.pg;
+
+public class PgApiResponse<T> {
+    private final Metadata meta;
+    private final T data;
+
+    public PgApiResponse(Metadata meta, T data) {
+        this.meta = meta;
+        this.data = data;
+    }
+
+    public static PgApiResponse<Object> success() {
+        return new PgApiResponse<>(Metadata.success(), null);
+    }
+
+    public static <T> PgApiResponse<T> success(T data) {
+        return new PgApiResponse<>(Metadata.success(), data);
+    }
+
+    public static PgApiResponse<Object> fail(String errorCode, String errorMessage) {
+        return new PgApiResponse<>(Metadata.fail(errorCode, errorMessage), null);
+    }
+
+    public Metadata getMeta() {
+        return meta;
+    }
+
+    public T getData() {
+        return data;
+    }
+
+    public static class Metadata {
+        private final Result result;
+        private final String errorCode;
+        private final String message;
+
+        public Metadata(Result result, String errorCode, String message) {
+            this.result = result;
+            this.errorCode = errorCode;
+            this.message = message;
+        }
+
+        public static Metadata success() {
+            return new Metadata(Result.SUCCESS, null, null);
+        }
+
+        public static Metadata fail(String errorCode, String errorMessage) {
+            return new Metadata(Result.FAIL, errorCode, errorMessage);
+        }
+
+        public Result getResult() {
+            return result;
+        }
+
+        public String getErrorCode() {
+            return errorCode;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public enum Result {SUCCESS, FAIL}
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/pg/PgProviderImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/pg/PgProviderImpl.java
@@ -1,0 +1,84 @@
+package com.loopers.infrastructure.pg;
+
+import com.loopers.domain.payment.*;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import com.loopers.support.resilience.ResilienceTemplate;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PgProviderImpl implements PgProvider<CardPaymentRequest> {
+
+    private static final Logger logger = LoggerFactory.getLogger(PgProviderImpl.class);
+    private static final String CALLBACK_URL = "http://localhost:8080/api/v1/payments/callback";
+
+    private final PgServiceClient pgServiceClient;
+    private final ResilienceTemplate resilienceTemplate;
+
+    @Override
+    public TransactionResult requestTransaction(CardPaymentRequest request) {
+        return TransactionResponse.toResult(resilienceTemplate.circuitBreaker(
+            "requestTransaction",
+            builder -> {
+            }, // 기본 설정 사용
+            () -> {
+                var res = pgServiceClient.requestTransaction(
+                    request.getMember().getUserId(),
+                    new TransactionRequest(
+                        OrderKeyEncoder.encode(request.getOrder().getId()),
+                        TransactionRequest.CardTypeDto.from(request.getCardType()),
+                        request.getCardNo(),
+                        request.getAmount().longValue(),
+                        CALLBACK_URL
+                    )
+                );
+                logger.info("### pgServiceClient.requestTransaction: {} ###", res);
+                return res.getData();
+            },
+            ex -> {
+                logger.warn("circuitBreaker exception during requestTransaction. {}", ex.e().getMessage());
+                throw new CoreException(ErrorType.SERVICE_UNAVAILABLE, "PG 시스템 장애로 인해 잠시 간 거래 요청을 처리할 수 없습니다.");
+            }
+        ));
+    }
+
+    @Override
+    public TransactionDetailResult getTransactionDetail(String userId, String transactionKey) {
+        return TransactionDetailResponse.toResult(resilienceTemplate.circuitBreaker(
+            "getTransactionDetail",
+            builder -> {
+            }, // 기본 설정 사용
+            () -> {
+                var res = pgServiceClient.getTransactionDetail(userId, transactionKey);
+                logger.info("### Transaction detail: {} ###", res);
+                return res.getData();
+            },
+            ex -> {
+                logger.warn("circuitBreaker exception during getTransactionDetail. {}", ex.e().getMessage());
+                throw new CoreException(ErrorType.SERVICE_UNAVAILABLE, "PG 시스템 장애로 인해 잠시 거래 상세 정보를 가져올 수 없습니다.");
+            }
+        ));
+    }
+
+    @Override
+    public OrderResult getTransactionsByOrder(String userId, String orderId) {
+        return OrderResponse.toResult(resilienceTemplate.circuitBreaker(
+            "getTransactionsByOrder",
+            builder -> {
+            }, // 기본 설정 사용
+            () -> {
+                var res = pgServiceClient.getTransactionsByOrder(userId, OrderKeyEncoder.encode(Long.parseLong(orderId)));
+                logger.info("### Transactions by order: {} ###", res);
+                return res.getData();
+            },
+            ex -> {
+                logger.warn("circuitBreaker exception during getTransactionsByOrder. {}", ex.e().getMessage());
+                throw new CoreException(ErrorType.SERVICE_UNAVAILABLE, "PG 시스템 장애로 인해 잠시 주문 거래 정보를 가져올 수 없습니다.");
+            }
+        ));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/pg/PgServiceClient.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/pg/PgServiceClient.java
@@ -1,0 +1,52 @@
+package com.loopers.infrastructure.pg;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import io.github.resilience4j.retry.annotation.Retry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.*;
+
+@FeignClient(name = "pg-service", url = "http://localhost:8082")
+public interface PgServiceClient {
+
+    Logger log = LoggerFactory.getLogger(PgServiceClient.class);
+
+    @PostMapping("/api/v1/payments")
+    @Retry(name = "requestTransaction", fallbackMethod = "fallbackRequestTransaction")
+    PgApiResponse<TransactionResponse> requestTransaction(
+        @RequestHeader("X-USER-ID") String userId,
+        @RequestBody() TransactionRequest body
+    );
+
+    @GetMapping("/api/v1/payments/{transactionKey}")
+    @Retry(name = "getTransactionDetail", fallbackMethod = "fallbackGetTransactionDetail")
+    PgApiResponse<TransactionDetailResponse> getTransactionDetail(
+        @RequestHeader("X-USER-ID") String userId,
+        @PathVariable("transactionKey") String transactionKey
+    );
+
+    @GetMapping("/api/v1/payments")
+    @Retry(name = "getTransactionsByOrder", fallbackMethod = "fallbackGetTransactionsByOrder")
+    PgApiResponse<OrderResponse> getTransactionsByOrder(
+        @RequestHeader("X-USER-ID") String userId,
+        @RequestParam("orderId") String orderId
+    );
+
+    default PgApiResponse<TransactionResponse> fallbackRequestTransaction(String userId, TransactionRequest body, Throwable e) {
+        log.error("리트라이 실패 - PG 시스템 장애로 인해 폴백 로직 실행: " + e.getMessage() + " for userId: " + userId);
+        throw new CoreException(ErrorType.SERVICE_UNAVAILABLE, "리트라이 실패 - PG 시스템 장애로 인해 잠시 간 거래 요청을 처리할 수 없습니다.");
+    }
+
+    default PgApiResponse<TransactionDetailResponse> fallbackGetTransactionDetail(String userId, String transactionKey, Throwable e) {
+        log.error("리트라이 실패 - PG 시스템 장애로 인해 폴백 로직 실행: " + e.getMessage() + " for userId: " + userId);
+        throw new CoreException(ErrorType.SERVICE_UNAVAILABLE, "리트라이 실패 - PG 시스템 장애로 인해 잠시 거래 상세 정보를 가져올 수 없습니다.");
+    }
+
+    default PgApiResponse<OrderResponse> fallbackGetTransactionsByOrder(String userId, String orderId, Throwable e) {
+        log.error("리트라이 실패 - PG 시스템 장애로 인해 폴백 로직 실행: " + e.getMessage() + " for userId: " + userId);
+        throw new CoreException(ErrorType.SERVICE_UNAVAILABLE, "리트라이 실패 - PG 시스템 장애로 인해 잠시 주문 거래 정보를 가져올 수 없습니다.");
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/pg/TransactionDetailResponse.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/pg/TransactionDetailResponse.java
@@ -1,0 +1,57 @@
+package com.loopers.infrastructure.pg;
+
+import com.loopers.domain.payment.CardType;
+import com.loopers.domain.payment.TransactionDetailResult;
+import com.loopers.domain.payment.TransactionStatus;
+
+import java.math.BigDecimal;
+
+public record TransactionDetailResponse(
+    String transactionKey,
+    String orderId,
+    CardTypeResponse cardType,
+    String cardNo,
+    BigDecimal amount,
+    TransactionStatusResponse status,
+    String reason
+) {
+    public static TransactionDetailResult toResult(TransactionDetailResponse response) {
+        return new TransactionDetailResult(
+            response.transactionKey(),
+            OrderKeyEncoder.decode(response.orderId()).toString(),
+            response.cardType().toCardType(),
+            response.cardNo(),
+            response.amount(),
+            response.status().toTransactionStatus(),
+            response.reason()
+        );
+    }
+
+    public enum CardTypeResponse {
+        SAMSUNG,
+        KB,
+        HYUNDAI;
+
+        public CardType toCardType() {
+            return switch (this) {
+                case SAMSUNG -> CardType.SAMSUNG;
+                case KB -> CardType.KB;
+                case HYUNDAI -> CardType.HYUNDAI;
+            };
+        }
+    }
+
+    public enum TransactionStatusResponse {
+        PENDING,
+        SUCCESS,
+        FAILED;
+
+        public TransactionStatus toTransactionStatus() {
+            return switch (this) {
+                case PENDING -> TransactionStatus.PENDING;
+                case SUCCESS -> TransactionStatus.SUCCESS;
+                case FAILED -> TransactionStatus.FAILED;
+            };
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/pg/TransactionRequest.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/pg/TransactionRequest.java
@@ -1,0 +1,26 @@
+package com.loopers.infrastructure.pg;
+
+import com.loopers.domain.payment.CardType;
+
+public record TransactionRequest(
+    String orderId,
+    CardTypeDto cardType,
+    String cardNo,
+    Long amount,
+    String callbackUrl
+) {
+    public enum CardTypeDto {
+        SAMSUNG,
+        KB,
+        HYUNDAI;
+
+        public static CardTypeDto from(CardType cardType) {
+            return switch (cardType) {
+                case SAMSUNG -> SAMSUNG;
+                case KB -> KB;
+                case HYUNDAI -> HYUNDAI;
+                default -> throw new IllegalArgumentException("Unknown card type: " + cardType);
+            };
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/pg/TransactionResponse.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/pg/TransactionResponse.java
@@ -1,0 +1,22 @@
+package com.loopers.infrastructure.pg;
+
+import com.loopers.domain.payment.TransactionResult;
+import com.loopers.domain.payment.TransactionStatus;
+
+public record TransactionResponse(String transactionKey, TransactionStatusResponse status, String reason) {
+    public static TransactionResult toResult(TransactionResponse response) {
+        return new TransactionResult(
+            response.transactionKey(),
+            response.status() == TransactionStatusResponse.PENDING ? TransactionStatus.PENDING
+                : response.status() == TransactionStatusResponse.SUCCESS ? TransactionStatus.SUCCESS
+                : TransactionStatus.FAILED,
+            response.reason()
+        );
+    }
+
+    public enum TransactionStatusResponse {
+        PENDING,
+        SUCCESS,
+        FAILED
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentV1ApiSpec.java
@@ -1,0 +1,15 @@
+package com.loopers.interfaces.api.payment;
+
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Payment V1 API")
+public interface PaymentV1ApiSpec {
+    @Operation(
+        summary = "결제 콜백 핸들러"
+    )
+    ApiResponse<Boolean> handlePaymentCallback(
+        PaymentV1Dto.PaymentCallbackRequest request
+    );
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentV1Controller.java
@@ -1,0 +1,38 @@
+package com.loopers.interfaces.api.payment;
+
+import com.loopers.application.payment.PaymentFacade;
+import com.loopers.application.payment.dto.SyncPaymentCommand;
+import com.loopers.interfaces.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/payments")
+public class PaymentV1Controller implements PaymentV1ApiSpec {
+
+    private final PaymentFacade paymentFacade;
+
+    @PostMapping("/callback")
+    @Override
+    public ApiResponse<Boolean> handlePaymentCallback(@RequestBody PaymentV1Dto.PaymentCallbackRequest request) {
+        log.warn("{} req, handlePaymentCallback", request);
+        paymentFacade.syncPayment(
+            new SyncPaymentCommand(
+                request.transactionKey(),
+                request.orderId(),
+                request.cardType(),
+                request.cardNo(),
+                request.amount(),
+                request.status(),
+                request.reason()
+            )
+        );
+        return ApiResponse.success(true);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentV1Dto.java
@@ -1,0 +1,16 @@
+package com.loopers.interfaces.api.payment;
+
+import com.loopers.application.payment.dto.SyncPaymentCommand;
+
+public class PaymentV1Dto {
+    public record PaymentCallbackRequest(
+        String transactionKey,
+        String orderId,
+        SyncPaymentCommand.CardTypeInfo cardType,
+        String cardNo,
+        Long amount,
+        SyncPaymentCommand.TransactionStatusInfo status,
+        String reason
+    ) {
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/support/error/ErrorType.java
+++ b/apps/commerce-api/src/main/java/com/loopers/support/error/ErrorType.java
@@ -11,6 +11,7 @@ public enum ErrorType {
      * 범용 에러
      */
     INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase(), "일시적인 오류가 발생했습니다."),
+    SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, HttpStatus.SERVICE_UNAVAILABLE.getReasonPhrase(), "서비스를 일시적으로 사용할 수 없습니다."),
     BAD_REQUEST(HttpStatus.BAD_REQUEST, HttpStatus.BAD_REQUEST.getReasonPhrase(), "잘못된 요청입니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, HttpStatus.NOT_FOUND.getReasonPhrase(), "존재하지 않는 요청입니다."),
     CONFLICT(HttpStatus.CONFLICT, HttpStatus.CONFLICT.getReasonPhrase(), "이미 존재하는 리소스입니다."),

--- a/apps/commerce-api/src/main/java/com/loopers/support/resilience/CircuitBreakerException.java
+++ b/apps/commerce-api/src/main/java/com/loopers/support/resilience/CircuitBreakerException.java
@@ -1,0 +1,8 @@
+package com.loopers.support.resilience;
+
+public record CircuitBreakerException(Throwable e, Reason reason) {
+    public enum Reason {
+        FAILURE,
+        SLOW
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/support/resilience/CircuitBreakerUtils.java
+++ b/apps/commerce-api/src/main/java/com/loopers/support/resilience/CircuitBreakerUtils.java
@@ -1,0 +1,15 @@
+package com.loopers.support.resilience;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+
+public class CircuitBreakerUtils {
+    public static CircuitBreakerException.Reason determineFailureReason(CircuitBreaker circuitBreaker) {
+        if (circuitBreaker.getMetrics().getFailureRate() >= circuitBreaker.getCircuitBreakerConfig().getFailureRateThreshold()) {
+            return CircuitBreakerException.Reason.FAILURE;
+        } else if (circuitBreaker.getMetrics().getSlowCallRate() >= circuitBreaker.getCircuitBreakerConfig().getSlowCallRateThreshold()) {
+            return CircuitBreakerException.Reason.SLOW;
+        } else {
+            return CircuitBreakerException.Reason.FAILURE;
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/support/resilience/ResilienceTemplate.java
+++ b/apps/commerce-api/src/main/java/com/loopers/support/resilience/ResilienceTemplate.java
@@ -1,0 +1,16 @@
+package com.loopers.support.resilience;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public interface ResilienceTemplate {
+    <T> T circuitBreaker(
+        String circuitBreakerName,
+        Consumer<CircuitBreakerConfig.Builder> configCustomizer,
+        Supplier<T> block,
+        Function<CircuitBreakerException, T> fallback
+    );
+}

--- a/apps/commerce-api/src/main/java/com/loopers/support/resilience/ResilienceTemplateImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/support/resilience/ResilienceTemplateImpl.java
@@ -1,0 +1,53 @@
+package com.loopers.support.resilience;
+
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+@Component
+@RequiredArgsConstructor
+public class ResilienceTemplateImpl implements ResilienceTemplate {
+    static Logger logger = LoggerFactory.getLogger(ResilienceTemplateImpl.class);
+
+    private final CircuitBreakerRegistry circuitBreakerRegistry;
+
+    @Override
+    public <T> T circuitBreaker(String circuitBreakerName, Consumer<CircuitBreakerConfig.Builder> configCustomizer, Supplier<T> block, Function<CircuitBreakerException, T> fallback) {
+        CircuitBreakerConfig config = circuitBreakerRegistry.getConfiguration(circuitBreakerName)
+            .orElseGet(() -> {
+                CircuitBreakerConfig.Builder builder = CircuitBreakerConfig.from(circuitBreakerRegistry.getDefaultConfig());
+                configCustomizer.accept(builder);
+                CircuitBreakerConfig builtConfig = builder.build();
+                circuitBreakerRegistry.addConfiguration(circuitBreakerName, builtConfig);
+                return builtConfig;
+            });
+
+        CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker(circuitBreakerName, config);
+
+        try {
+            return circuitBreaker.executeCallable(block::get);
+        } catch (Throwable e) {
+            CircuitBreakerException.Reason reason;
+            if (e instanceof CallNotPermittedException) {
+                reason = CircuitBreakerUtils.determineFailureReason(circuitBreaker);
+                switch (reason) {
+                    case FAILURE -> logger.error("CircuitBreaker FAILURE", e);
+                    case SLOW -> logger.warn("CircuitBreaker SLOW", e);
+                }
+            } else {
+                logger.error("CircuitBreaker Exception", e);
+                reason = CircuitBreakerException.Reason.FAILURE;
+            }
+            return fallback.apply(new CircuitBreakerException(e, reason));
+        }
+    }
+}

--- a/apps/commerce-api/src/main/resources/application.yml
+++ b/apps/commerce-api/src/main/resources/application.yml
@@ -29,6 +29,39 @@ springdoc:
   swagger-ui:
     path: /swagger-ui.html
 
+feign:
+  client:
+    config:
+      default:
+        connectTimeout: 2000
+        readTimeout: 5000
+
+resilience4j:
+  circuitbreaker:
+    configs:
+      default:
+        failure-rate-threshold: 50 # 실패율 50% 초과 시 오픈
+        slow-call-rate-threshold: 50 # 느린 호출 비율 50% 초과 시 오픈
+        slow-call-duration-threshold: 500 # 500ms 이상 응답을 느린 호출로 간주
+        permitted-number-of-calls-in-half-open-state: 1 # half-open 상태에서 허용되는 호출 수
+        max-wait-duration-in-half-open-state: 500 # half-open 상태에서 최대 대기 시간 500ms
+        sliding-window-type: time_based
+        sliding-window-size: 10 # 최근 10개 호출을 기준으로 실패율 계산
+        minimum-number-of-calls: 2 # 최소 2개 호출이 있어야 서킷브레이커 동작
+        wait-duration-in-open-state: 1000 # 오픈 상태에서 1초 후 half-open 상태로 전환
+        event-consumer-buffer-size: 1
+        register-health-indicator: true
+        record-exceptions:
+          - java.lang.Throwable
+  retry:
+    instances:
+      pgService:
+        max-attempts: 1
+        wait-duration: 1000
+        retry-exceptions:
+          - feign.RetryableException
+          - java.net.SocketTimeoutException
+
 ---
 spring:
   config:

--- a/apps/commerce-api/src/test/java/com/loopers/domain/orders/OrderServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/orders/OrderServiceTest.java
@@ -54,7 +54,7 @@ class OrderServiceTest {
 
             when(orderRepository.save(any(OrdersModel.class))).thenReturn(order);
 
-            OrdersModel result = orderService.order(member, products, null);
+            OrdersModel result = orderService.order(member, products, null, Price.of(new BigDecimal("2000")));
 
             assertThat(result).isNotNull();
             verify(orderRepository).save(any(OrdersModel.class));
@@ -64,7 +64,7 @@ class OrderServiceTest {
         @DisplayName("member가 null이면 BAD_REQUEST 예외 발생")
         void order_memberNull_throwsException() {
             List<Pair<ProductModel, Long>> products = List.of();
-            CoreException ex = assertThrows(CoreException.class, () -> orderService.order(null, products, null));
+            CoreException ex = assertThrows(CoreException.class, () -> orderService.order(null, products, null, Price.of(new BigDecimal("1000"))));
             assertThat(ex.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
         }
 
@@ -72,7 +72,7 @@ class OrderServiceTest {
         @DisplayName("products가 null이면 BAD_REQUEST 예외 발생")
         void order_productsNull_throwsException() {
             MemberModel member = new MemberModel("user1", Gender.FEMALE, "2000-01-01", "test@test.com", 1000L);
-            CoreException ex = assertThrows(CoreException.class, () -> orderService.order(member, null, null));
+            CoreException ex = assertThrows(CoreException.class, () -> orderService.order(member, null, null, Price.of(new BigDecimal("2000"))));
             assertThat(ex.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
         }
 
@@ -80,7 +80,7 @@ class OrderServiceTest {
         @DisplayName("products가 비어있으면 BAD_REQUEST 예외 발생")
         void order_productsEmpty_throwsException() {
             MemberModel member = new MemberModel("user1", Gender.FEMALE, "2000-01-01", "test@test.com", 1000L);
-            CoreException ex = assertThrows(CoreException.class, () -> orderService.order(member, Collections.emptyList(), null));
+            CoreException ex = assertThrows(CoreException.class, () -> orderService.order(member, Collections.emptyList(), null, Price.of(new BigDecimal("2000"))));
             assertThat(ex.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
         }
 
@@ -92,7 +92,7 @@ class OrderServiceTest {
             ProductModel product = new ProductModel("p1", com.loopers.domain.product.vo.Price.ZERO, Stock.of(1568), 369L);
             ReflectionTestUtils.setField(product, "id", 123L);
             List<Pair<ProductModel, Long>> products = List.of(Pair.of(product, 0L));
-            CoreException ex = assertThrows(CoreException.class, () -> orderService.order(member, products, null));
+            CoreException ex = assertThrows(CoreException.class, () -> orderService.order(member, products, null, Price.of(new BigDecimal("2000"))));
             assertThat(ex.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
         }
     }

--- a/apps/pg-simulator/README.md
+++ b/apps/pg-simulator/README.md
@@ -1,0 +1,42 @@
+## PG-Simulator (PaymentGateway)
+
+### Description
+Loopback BE 과정을 위해 PaymentGateway 를 시뮬레이션하는 App Module 입니다.
+`local` 프로필로 실행 권장하며, 커머스 서비스와의 동시 실행을 위해 서버 포트가 조정되어 있습니다.
+- server port : 8082
+- actuator port : 8083
+
+### Getting Started
+부트 서버를 아래 명령어 혹은 `intelliJ` 통해 실행해주세요.
+```shell
+./gradlew :apps:pg-simulator:bootRun
+```
+
+API 는 아래와 같이 주어지니, 커머스 서비스와 동시에 실행시킨 후 진행해주시면 됩니다.
+- 결제 요청 API
+- 결제 정보 확인 `by transactionKey`
+- 결제 정보 목록 조회 `by orderId`
+
+```http request
+### 결제 요청
+POST {{pg-simulator}}/api/v1/payments
+X-USER-ID: 135135
+Content-Type: application/json
+
+{
+  "orderId": "1351039135",
+  "cardType": "SAMSUNG",
+  "cardNo": "1234-5678-9814-1451",
+  "amount" : "5000",
+  "callbackUrl": "http://localhost:8080/api/v1/examples/callback"
+}
+
+### 결제 정보 확인
+GET {{pg-simulator}}/api/v1/payments/20250816:TR:9577c5
+X-USER-ID: 135135
+
+### 주문에 엮인 결제 정보 조회
+GET {{pg-simulator}}/api/v1/payments?orderId=1351039135
+X-USER-ID: 135135
+
+```

--- a/apps/pg-simulator/build.gradle.kts
+++ b/apps/pg-simulator/build.gradle.kts
@@ -1,0 +1,40 @@
+plugins {
+    val kotlinVersion = "2.0.20"
+
+    id("org.jetbrains.kotlin.jvm") version(kotlinVersion)
+    id("org.jetbrains.kotlin.kapt") version(kotlinVersion)
+    id("org.jetbrains.kotlin.plugin.spring") version(kotlinVersion)
+    id("org.jetbrains.kotlin.plugin.jpa") version(kotlinVersion)
+}
+
+kotlin {
+    compilerOptions {
+        jvmToolchain(21)
+        freeCompilerArgs.addAll("-Xjsr305=strict")
+    }
+}
+
+dependencies {
+    // add-ons
+    implementation(project(":modules:jpa"))
+    implementation(project(":modules:redis"))
+    implementation(project(":supports:jackson"))
+    implementation(project(":supports:logging"))
+    implementation(project(":supports:monitoring"))
+
+    // kotlin
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+
+    // web
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:${project.properties["springDocOpenApiVersion"]}")
+
+    // querydsl
+    kapt("com.querydsl:querydsl-apt::jakarta")
+
+    // test-fixtures
+    testImplementation(testFixtures(project(":modules:jpa")))
+    testImplementation(testFixtures(project(":modules:redis")))
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/PaymentGatewayApplication.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/PaymentGatewayApplication.kt
@@ -1,0 +1,24 @@
+package com.loopers
+
+import jakarta.annotation.PostConstruct
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
+import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableAsync
+import java.util.TimeZone
+
+@ConfigurationPropertiesScan
+@EnableAsync
+@SpringBootApplication
+class PaymentGatewayApplication {
+
+    @PostConstruct
+    fun started() {
+        // set timezone
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"))
+    }
+}
+
+fun main(args: Array<String>) {
+    runApplication<PaymentGatewayApplication>(*args)
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/OrderInfo.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/OrderInfo.kt
@@ -1,0 +1,14 @@
+package com.loopers.application.payment
+
+/**
+ * 결제 주문 정보
+ *
+ * 결제는 주문에 대한 다수 트랜잭션으로 구성됩니다.
+ *
+ * @property orderId 주문 정보
+ * @property transactions 주문에 엮인 트랜잭션 목록
+ */
+data class OrderInfo(
+    val orderId: String,
+    val transactions: List<TransactionInfo>,
+)

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/PaymentApplicationService.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/PaymentApplicationService.kt
@@ -1,0 +1,88 @@
+package com.loopers.application.payment
+
+import com.loopers.domain.payment.Payment
+import com.loopers.domain.payment.PaymentEvent
+import com.loopers.domain.payment.PaymentEventPublisher
+import com.loopers.domain.payment.PaymentRelay
+import com.loopers.domain.payment.PaymentRepository
+import com.loopers.domain.payment.TransactionKeyGenerator
+import com.loopers.domain.user.UserInfo
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class PaymentApplicationService(
+    private val paymentRepository: PaymentRepository,
+    private val paymentEventPublisher: PaymentEventPublisher,
+    private val paymentRelay: PaymentRelay,
+    private val transactionKeyGenerator: TransactionKeyGenerator,
+) {
+    companion object {
+        private val RATE_LIMIT_EXCEEDED = (1..20)
+        private val RATE_INVALID_CARD = (21..30)
+    }
+
+    @Transactional
+    fun createTransaction(command: PaymentCommand.CreateTransaction): TransactionInfo {
+        command.validate()
+
+        val transactionKey = transactionKeyGenerator.generate()
+        val payment = paymentRepository.save(
+            Payment(
+                transactionKey = transactionKey,
+                userId = command.userId,
+                orderId = command.orderId,
+                cardType = command.cardType,
+                cardNo = command.cardNo,
+                amount = command.amount,
+                callbackUrl = command.callbackUrl,
+            ),
+        )
+
+        paymentEventPublisher.publish(PaymentEvent.PaymentCreated.from(payment = payment))
+
+        return TransactionInfo.from(payment)
+    }
+
+    @Transactional(readOnly = true)
+    fun getTransactionDetailInfo(userInfo: UserInfo, transactionKey: String): TransactionInfo {
+        val payment = paymentRepository.findByTransactionKey(userId = userInfo.userId, transactionKey = transactionKey)
+            ?: throw CoreException(ErrorType.NOT_FOUND, "(transactionKey: $transactionKey) 결제건이 존재하지 않습니다.")
+        return TransactionInfo.from(payment)
+    }
+
+    @Transactional(readOnly = true)
+    fun findTransactionsByOrderId(userInfo: UserInfo, orderId: String): OrderInfo {
+        val payments = paymentRepository.findByOrderId(userId = userInfo.userId, orderId = orderId)
+        if (payments.isEmpty()) {
+            throw CoreException(ErrorType.NOT_FOUND, "(orderId: $orderId) 에 해당하는 결제건이 존재하지 않습니다.")
+        }
+
+        return OrderInfo(
+            orderId = orderId,
+            transactions = payments.map { TransactionInfo.from(it) },
+        )
+    }
+
+    @Transactional
+    fun handle(transactionKey: String) {
+        val payment = paymentRepository.findByTransactionKey(transactionKey)
+            ?: throw CoreException(ErrorType.NOT_FOUND, "(transactionKey: $transactionKey) 결제건이 존재하지 않습니다.")
+
+        val rate = (1..100).random()
+        when (rate) {
+            in RATE_LIMIT_EXCEEDED -> payment.limitExceeded()
+            in RATE_INVALID_CARD -> payment.invalidCard()
+            else -> payment.approve()
+        }
+        paymentEventPublisher.publish(event = PaymentEvent.PaymentHandled.from(payment))
+    }
+
+    fun notifyTransactionResult(transactionKey: String) {
+        val payment = paymentRepository.findByTransactionKey(transactionKey)
+            ?: throw CoreException(ErrorType.NOT_FOUND, "(transactionKey: $transactionKey) 결제건이 존재하지 않습니다.")
+        paymentRelay.notify(callbackUrl = payment.callbackUrl, transactionInfo = TransactionInfo.from(payment))
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/PaymentCommand.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/PaymentCommand.kt
@@ -1,0 +1,22 @@
+package com.loopers.application.payment
+
+import com.loopers.domain.payment.CardType
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+
+object PaymentCommand {
+    data class CreateTransaction(
+        val userId: String,
+        val orderId: String,
+        val cardType: CardType,
+        val cardNo: String,
+        val amount: Long,
+        val callbackUrl: String,
+    ) {
+        fun validate() {
+            if (amount <= 0L) {
+                throw CoreException(ErrorType.BAD_REQUEST, "요청 금액은 0 보다 큰 정수여야 합니다.")
+            }
+        }
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/TransactionInfo.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/TransactionInfo.kt
@@ -1,0 +1,39 @@
+package com.loopers.application.payment
+
+import com.loopers.domain.payment.CardType
+import com.loopers.domain.payment.Payment
+import com.loopers.domain.payment.TransactionStatus
+
+/**
+ * 트랜잭션 정보
+ *
+ * @property transactionKey 트랜잭션 KEY
+ * @property orderId 주문 ID
+ * @property cardType 카드 종류
+ * @property cardNo 카드 번호
+ * @property amount 금액
+ * @property status 처리 상태
+ * @property reason 처리 사유
+ */
+data class TransactionInfo(
+    val transactionKey: String,
+    val orderId: String,
+    val cardType: CardType,
+    val cardNo: String,
+    val amount: Long,
+    val status: TransactionStatus,
+    val reason: String?,
+) {
+    companion object {
+        fun from(payment: Payment): TransactionInfo =
+            TransactionInfo(
+                transactionKey = payment.transactionKey,
+                orderId = payment.orderId,
+                cardType = payment.cardType,
+                cardNo = payment.cardNo,
+                amount = payment.amount,
+                status = payment.status,
+                reason = payment.reason,
+            )
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/config/web/WebMvcConfig.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/config/web/WebMvcConfig.kt
@@ -1,0 +1,13 @@
+package com.loopers.config.web
+
+import com.loopers.interfaces.api.argumentresolver.UserInfoArgumentResolver
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebMvcConfig : WebMvcConfigurer {
+    override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver?>) {
+        resolvers.add(UserInfoArgumentResolver())
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/CardType.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/CardType.kt
@@ -1,0 +1,7 @@
+package com.loopers.domain.payment
+
+enum class CardType {
+    SAMSUNG,
+    KB,
+    HYUNDAI,
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/Payment.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/Payment.kt
@@ -1,0 +1,87 @@
+package com.loopers.domain.payment
+
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity
+@Table(
+    name = "payments",
+    indexes = [
+        Index(name = "idx_user_transaction", columnList = "user_id, transaction_key"),
+        Index(name = "idx_user_order", columnList = "user_id, order_id"),
+        Index(name = "idx_unique_user_order_transaction", columnList = "user_id, order_id, transaction_key", unique = true),
+    ]
+)
+class Payment(
+    @Id
+    @Column(name = "transaction_key", nullable = false, unique = true)
+    val transactionKey: String,
+
+    @Column(name = "user_id", nullable = false)
+    val userId: String,
+
+    @Column(name = "order_id", nullable = false)
+    val orderId: String,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "card_type", nullable = false)
+    val cardType: CardType,
+
+    @Column(name = "card_no", nullable = false)
+    val cardNo: String,
+
+    @Column(name = "amount", nullable = false)
+    val amount: Long,
+
+    @Column(name = "callback_url", nullable = false)
+    val callbackUrl: String,
+) {
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    var status: TransactionStatus = TransactionStatus.PENDING
+        private set
+
+    @Column(name = "reason", nullable = true)
+    var reason: String? = null
+        private set
+
+    @Column(name = "created_at", nullable = false)
+    var createdAt: LocalDateTime = LocalDateTime.now()
+        private set
+
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: LocalDateTime = LocalDateTime.now()
+        private set
+
+    fun approve() {
+        if (status != TransactionStatus.PENDING) {
+            throw CoreException(ErrorType.INTERNAL_ERROR, "결제승인은 대기상태에서만 가능합니다.")
+        }
+        status = TransactionStatus.SUCCESS
+        reason = "정상 승인되었습니다."
+    }
+
+    fun invalidCard() {
+        if (status != TransactionStatus.PENDING) {
+            throw CoreException(ErrorType.INTERNAL_ERROR, "결제처리는 대기상태에서만 가능합니다.")
+        }
+        status = TransactionStatus.FAILED
+        reason = "잘못된 카드입니다. 다른 카드를 선택해주세요."
+    }
+
+    fun limitExceeded() {
+        if (status != TransactionStatus.PENDING) {
+            throw CoreException(ErrorType.INTERNAL_ERROR, "한도초과 처리는 대기상태에서만 가능합니다.")
+        }
+        status = TransactionStatus.FAILED
+        reason = "한도초과입니다. 다른 카드를 선택해주세요."
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentEvent.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentEvent.kt
@@ -1,0 +1,28 @@
+package com.loopers.domain.payment
+
+object PaymentEvent {
+    data class PaymentCreated(
+        val transactionKey: String,
+    ) {
+        companion object {
+            fun from(payment: Payment): PaymentCreated = PaymentCreated(transactionKey = payment.transactionKey)
+        }
+    }
+
+    data class PaymentHandled(
+        val transactionKey: String,
+        val status: TransactionStatus,
+        val reason: String?,
+        val callbackUrl: String,
+    ) {
+        companion object {
+            fun from(payment: Payment): PaymentHandled =
+                PaymentHandled(
+                    transactionKey = payment.transactionKey,
+                    status = payment.status,
+                    reason = payment.reason,
+                    callbackUrl = payment.callbackUrl,
+                )
+        }
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentEventPublisher.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentEventPublisher.kt
@@ -1,0 +1,6 @@
+package com.loopers.domain.payment
+
+interface PaymentEventPublisher {
+    fun publish(event: PaymentEvent.PaymentCreated)
+    fun publish(event: PaymentEvent.PaymentHandled)
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentRelay.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentRelay.kt
@@ -1,0 +1,7 @@
+package com.loopers.domain.payment
+
+import com.loopers.application.payment.TransactionInfo
+
+interface PaymentRelay {
+    fun notify(callbackUrl: String, transactionInfo: TransactionInfo)
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentRepository.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentRepository.kt
@@ -1,0 +1,8 @@
+package com.loopers.domain.payment
+
+interface PaymentRepository {
+    fun save(payment: Payment): Payment
+    fun findByTransactionKey(transactionKey: String): Payment?
+    fun findByTransactionKey(userId: String, transactionKey: String): Payment?
+    fun findByOrderId(userId: String, orderId: String): List<Payment>
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/TransactionKeyGenerator.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/TransactionKeyGenerator.kt
@@ -1,0 +1,20 @@
+package com.loopers.domain.payment
+
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.util.UUID
+
+@Component
+class TransactionKeyGenerator {
+    companion object {
+        private const val KEY_TRANSACTION = "TR"
+        private val DATETIME_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd")
+    }
+
+    fun generate(): String {
+        val now = LocalDateTime.now()
+        val uuid = UUID.randomUUID().toString().replace("-", "").substring(0, 6)
+        return "${DATETIME_FORMATTER.format(now)}:$KEY_TRANSACTION:$uuid"
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/TransactionStatus.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/TransactionStatus.kt
@@ -1,0 +1,7 @@
+package com.loopers.domain.payment
+
+enum class TransactionStatus {
+    PENDING,
+    SUCCESS,
+    FAILED
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/user/UserInfo.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/user/UserInfo.kt
@@ -1,0 +1,8 @@
+package com.loopers.domain.user
+
+/**
+ * user 정보
+ *
+ * @param userId 유저 식별자
+ */
+data class UserInfo(val userId: String)

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentCoreEventPublisher.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentCoreEventPublisher.kt
@@ -1,0 +1,19 @@
+package com.loopers.infrastructure.payment
+
+import com.loopers.domain.payment.PaymentEvent
+import com.loopers.domain.payment.PaymentEventPublisher
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
+
+@Component
+class PaymentCoreEventPublisher(
+    private val applicationEventPublisher: ApplicationEventPublisher,
+) : PaymentEventPublisher {
+    override fun publish(event: PaymentEvent.PaymentCreated) {
+        applicationEventPublisher.publishEvent(event)
+    }
+
+    override fun publish(event: PaymentEvent.PaymentHandled) {
+        applicationEventPublisher.publishEvent(event)
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentCoreRelay.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentCoreRelay.kt
@@ -1,0 +1,21 @@
+package com.loopers.infrastructure.payment
+
+import com.loopers.application.payment.TransactionInfo
+import com.loopers.domain.payment.PaymentRelay
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestTemplate
+
+@Component
+class PaymentCoreRelay : PaymentRelay {
+    companion object {
+        private val logger = LoggerFactory.getLogger(PaymentCoreRelay::class.java)
+        private val restTemplate = RestTemplate()
+    }
+
+    override fun notify(callbackUrl: String, transactionInfo: TransactionInfo) {
+        runCatching {
+            restTemplate.postForEntity(callbackUrl, transactionInfo, Any::class.java)
+        }.onFailure { e -> logger.error("콜백 호출을 실패했습니다. {}", e.message, e) }
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentCoreRepository.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentCoreRepository.kt
@@ -1,0 +1,32 @@
+package com.loopers.infrastructure.payment
+
+import com.loopers.domain.payment.Payment
+import com.loopers.domain.payment.PaymentRepository
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import kotlin.jvm.optionals.getOrNull
+
+@Component
+class PaymentCoreRepository(
+    private val paymentJpaRepository: PaymentJpaRepository,
+) : PaymentRepository {
+    @Transactional
+    override fun save(payment: Payment): Payment {
+        return paymentJpaRepository.save(payment)
+    }
+
+    @Transactional(readOnly = true)
+    override fun findByTransactionKey(transactionKey: String): Payment? {
+        return paymentJpaRepository.findById(transactionKey).getOrNull()
+    }
+
+    @Transactional(readOnly = true)
+    override fun findByTransactionKey(userId: String, transactionKey: String): Payment? {
+        return paymentJpaRepository.findByUserIdAndTransactionKey(userId, transactionKey)
+    }
+
+    override fun findByOrderId(userId: String, orderId: String): List<Payment> {
+        return paymentJpaRepository.findByUserIdAndOrderId(userId, orderId)
+            .sortedByDescending { it.updatedAt }
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentJpaRepository.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentJpaRepository.kt
@@ -1,0 +1,9 @@
+package com.loopers.infrastructure.payment
+
+import com.loopers.domain.payment.Payment
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface PaymentJpaRepository : JpaRepository<Payment, String> {
+    fun findByUserIdAndTransactionKey(userId: String, transactionKey: String): Payment?
+    fun findByUserIdAndOrderId(userId: String, orderId: String): List<Payment>
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/ApiControllerAdvice.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/ApiControllerAdvice.kt
@@ -1,0 +1,119 @@
+package com.loopers.interfaces.api
+
+import com.fasterxml.jackson.databind.JsonMappingException
+import com.fasterxml.jackson.databind.exc.InvalidFormatException
+import com.fasterxml.jackson.databind.exc.MismatchedInputException
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.web.bind.MissingServletRequestParameterException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
+import org.springframework.web.server.ServerWebInputException
+import org.springframework.web.servlet.resource.NoResourceFoundException
+import kotlin.collections.joinToString
+import kotlin.jvm.java
+import kotlin.text.isNotEmpty
+import kotlin.text.toRegex
+
+@RestControllerAdvice
+class ApiControllerAdvice {
+    private val log = LoggerFactory.getLogger(ApiControllerAdvice::class.java)
+
+    @ExceptionHandler
+    fun handle(e: CoreException): ResponseEntity<ApiResponse<*>> {
+        log.warn("CoreException : {}", e.customMessage ?: e.message, e)
+        return failureResponse(errorType = e.errorType, errorMessage = e.customMessage)
+    }
+
+    @ExceptionHandler
+    fun handleBadRequest(e: MethodArgumentTypeMismatchException): ResponseEntity<ApiResponse<*>> {
+        val name = e.name
+        val type = e.requiredType?.simpleName ?: "unknown"
+        val value = e.value ?: "null"
+        val message = "요청 파라미터 '$name' (타입: $type)의 값 '$value'이(가) 잘못되었습니다."
+        return failureResponse(errorType = ErrorType.BAD_REQUEST, errorMessage = message)
+    }
+
+    @ExceptionHandler
+    fun handleBadRequest(e: MissingServletRequestParameterException): ResponseEntity<ApiResponse<*>> {
+        val name = e.parameterName
+        val type = e.parameterType
+        val message = "필수 요청 파라미터 '$name' (타입: $type)가 누락되었습니다."
+        return failureResponse(errorType = ErrorType.BAD_REQUEST, errorMessage = message)
+    }
+
+    @ExceptionHandler
+    fun handleBadRequest(e: HttpMessageNotReadableException): ResponseEntity<ApiResponse<*>> {
+        val errorMessage = when (val rootCause = e.rootCause) {
+            is InvalidFormatException -> {
+                val fieldName = rootCause.path.joinToString(".") { it.fieldName ?: "?" }
+
+                val valueIndicationMessage = when {
+                    rootCause.targetType.isEnum -> {
+                        val enumClass = rootCause.targetType
+                        val enumValues = enumClass.enumConstants.joinToString(", ") { it.toString() }
+                        "사용 가능한 값 : [$enumValues]"
+                    }
+
+                    else -> ""
+                }
+
+                val expectedType = rootCause.targetType.simpleName
+                val value = rootCause.value
+
+                "필드 '$fieldName'의 값 '$value'이(가) 예상 타입($expectedType)과 일치하지 않습니다. $valueIndicationMessage"
+            }
+
+            is MismatchedInputException -> {
+                val fieldPath = rootCause.path.joinToString(".") { it.fieldName ?: "?" }
+                "필수 필드 '$fieldPath'이(가) 누락되었습니다."
+            }
+
+            is JsonMappingException -> {
+                val fieldPath = rootCause.path.joinToString(".") { it.fieldName ?: "?" }
+                "필드 '$fieldPath'에서 JSON 매핑 오류가 발생했습니다: ${rootCause.originalMessage}"
+            }
+
+            else -> "요청 본문을 처리하는 중 오류가 발생했습니다. JSON 메세지 규격을 확인해주세요."
+        }
+
+        return failureResponse(errorType = ErrorType.BAD_REQUEST, errorMessage = errorMessage)
+    }
+
+    @ExceptionHandler
+    fun handleBadRequest(e: ServerWebInputException): ResponseEntity<ApiResponse<*>> {
+        fun extractMissingParameter(message: String): String {
+            val regex = "'(.+?)'".toRegex()
+            return regex.find(message)?.groupValues?.get(1) ?: ""
+        }
+
+        val missingParams = extractMissingParameter(e.reason ?: "")
+        return if (missingParams.isNotEmpty()) {
+            failureResponse(errorType = ErrorType.BAD_REQUEST, errorMessage = "필수 요청 값 \'$missingParams\'가 누락되었습니다.")
+        } else {
+            failureResponse(errorType = ErrorType.BAD_REQUEST)
+        }
+    }
+
+    @ExceptionHandler
+    fun handleNotFound(e: NoResourceFoundException): ResponseEntity<ApiResponse<*>> {
+        return failureResponse(errorType = ErrorType.NOT_FOUND)
+    }
+
+    @ExceptionHandler
+    fun handle(e: Throwable): ResponseEntity<ApiResponse<*>> {
+        log.error("Exception : {}", e.message, e)
+        val errorType = ErrorType.INTERNAL_ERROR
+        return failureResponse(errorType = errorType)
+    }
+
+    private fun failureResponse(errorType: ErrorType, errorMessage: String? = null): ResponseEntity<ApiResponse<*>> =
+        ResponseEntity(
+            ApiResponse.fail(errorCode = errorType.code, errorMessage = errorMessage ?: errorType.message),
+            errorType.status,
+        )
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/ApiResponse.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/ApiResponse.kt
@@ -1,0 +1,32 @@
+package com.loopers.interfaces.api
+
+data class ApiResponse<T>(
+    val meta: Metadata,
+    val data: T?,
+) {
+    data class Metadata(
+        val result: Result,
+        val errorCode: String?,
+        val message: String?,
+    ) {
+        enum class Result { SUCCESS, FAIL }
+
+        companion object {
+            fun success() = Metadata(Result.SUCCESS, null, null)
+
+            fun fail(errorCode: String, errorMessage: String) = Metadata(Result.FAIL, errorCode, errorMessage)
+        }
+    }
+
+    companion object {
+        fun success(): ApiResponse<Any> = ApiResponse(Metadata.success(), null)
+
+        fun <T> success(data: T? = null) = ApiResponse(Metadata.success(), data)
+
+        fun fail(errorCode: String, errorMessage: String): ApiResponse<Any?> =
+            ApiResponse(
+                meta = Metadata.fail(errorCode = errorCode, errorMessage = errorMessage),
+                data = null,
+            )
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/argumentresolver/UserInfoArgumentResolver.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/argumentresolver/UserInfoArgumentResolver.kt
@@ -1,0 +1,32 @@
+package com.loopers.interfaces.api.argumentresolver
+
+import com.loopers.domain.user.UserInfo
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import org.springframework.core.MethodParameter
+import org.springframework.web.bind.support.WebDataBinderFactory
+import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.method.support.ModelAndViewContainer
+
+class UserInfoArgumentResolver: HandlerMethodArgumentResolver {
+    companion object {
+        private const val KEY_USER_ID = "X-USER-ID"
+    }
+
+    override fun supportsParameter(parameter: MethodParameter): Boolean {
+        return UserInfo::class.java.isAssignableFrom(parameter.parameterType)
+    }
+
+    override fun resolveArgument(
+        parameter: MethodParameter,
+        mavContainer: ModelAndViewContainer?,
+        webRequest: NativeWebRequest,
+        binderFactory: WebDataBinderFactory?,
+    ): UserInfo {
+        val userId = webRequest.getHeader(KEY_USER_ID)
+            ?: throw CoreException(ErrorType.BAD_REQUEST, "유저 ID 헤더는 필수입니다.")
+
+        return UserInfo(userId)
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/payment/PaymentApi.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/payment/PaymentApi.kt
@@ -1,0 +1,60 @@
+package com.loopers.interfaces.api.payment
+
+import com.loopers.application.payment.PaymentApplicationService
+import com.loopers.interfaces.api.ApiResponse
+import com.loopers.domain.user.UserInfo
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/payments")
+class PaymentApi(
+    private val paymentApplicationService: PaymentApplicationService,
+) {
+    @PostMapping
+    fun request(
+        userInfo: UserInfo,
+        @RequestBody request: PaymentDto.PaymentRequest,
+    ): ApiResponse<PaymentDto.TransactionResponse> {
+        request.validate()
+
+        // 100ms ~ 500ms 지연
+        Thread.sleep((100..500L).random())
+
+        // 40% 확률로 요청 실패
+        if ((1..100).random() <= 40) {
+            throw CoreException(ErrorType.INTERNAL_ERROR, "현재 서버가 불안정합니다. 잠시 후 다시 시도해주세요.")
+        }
+
+        return paymentApplicationService.createTransaction(request.toCommand(userInfo.userId))
+            .let { PaymentDto.TransactionResponse.from(it) }
+            .let { ApiResponse.success(it) }
+    }
+
+    @GetMapping("/{transactionKey}")
+    fun getTransaction(
+        userInfo: UserInfo,
+        @PathVariable("transactionKey") transactionKey: String,
+    ): ApiResponse<PaymentDto.TransactionDetailResponse> {
+        return paymentApplicationService.getTransactionDetailInfo(userInfo, transactionKey)
+            .let { PaymentDto.TransactionDetailResponse.from(it) }
+            .let { ApiResponse.success(it) }
+    }
+
+    @GetMapping
+    fun getTransactionsByOrder(
+        userInfo: UserInfo,
+        @RequestParam("orderId", required = false) orderId: String,
+    ): ApiResponse<PaymentDto.OrderResponse> {
+        return paymentApplicationService.findTransactionsByOrderId(userInfo, orderId)
+            .let { PaymentDto.OrderResponse.from(it) }
+            .let { ApiResponse.success(it) }
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/payment/PaymentDto.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/payment/PaymentDto.kt
@@ -1,0 +1,136 @@
+package com.loopers.interfaces.api.payment
+
+import com.loopers.application.payment.OrderInfo
+import com.loopers.application.payment.PaymentCommand
+import com.loopers.application.payment.TransactionInfo
+import com.loopers.domain.payment.CardType
+import com.loopers.domain.payment.TransactionStatus
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+
+object PaymentDto {
+    data class PaymentRequest(
+        val orderId: String,
+        val cardType: CardTypeDto,
+        val cardNo: String,
+        val amount: Long,
+        val callbackUrl: String,
+    ) {
+        companion object {
+            private val REGEX_CARD_NO = Regex("^\\d{4}-\\d{4}-\\d{4}-\\d{4}$")
+            private const val PREFIX_CALLBACK_URL = "http://localhost:8080"
+        }
+
+        fun validate() {
+            if (orderId.isBlank() || orderId.length < 6) {
+                throw CoreException(ErrorType.BAD_REQUEST, "주문 ID는 6자리 이상 문자열이어야 합니다.")
+            }
+            if (!REGEX_CARD_NO.matches(cardNo)) {
+                throw CoreException(ErrorType.BAD_REQUEST, "카드 번호는 xxxx-xxxx-xxxx-xxxx 형식이어야 합니다.")
+            }
+            if (amount <= 0) {
+                throw CoreException(ErrorType.BAD_REQUEST, "결제금액은 양의 정수여야 합니다.")
+            }
+            if (!callbackUrl.startsWith(PREFIX_CALLBACK_URL)) {
+                throw CoreException(ErrorType.BAD_REQUEST, "콜백 URL 은 $PREFIX_CALLBACK_URL 로 시작해야 합니다.")
+            }
+        }
+
+        fun toCommand(userId: String): PaymentCommand.CreateTransaction =
+            PaymentCommand.CreateTransaction(
+                userId = userId,
+                orderId = orderId,
+                cardType = cardType.toCardType(),
+                cardNo = cardNo,
+                amount = amount,
+                callbackUrl = callbackUrl,
+            )
+    }
+
+    data class TransactionDetailResponse(
+        val transactionKey: String,
+        val orderId: String,
+        val cardType: CardTypeDto,
+        val cardNo: String,
+        val amount: Long,
+        val status: TransactionStatusResponse,
+        val reason: String?,
+    ) {
+        companion object {
+            fun from(transactionInfo: TransactionInfo): TransactionDetailResponse =
+                TransactionDetailResponse(
+                    transactionKey = transactionInfo.transactionKey,
+                    orderId = transactionInfo.orderId,
+                    cardType = CardTypeDto.from(transactionInfo.cardType),
+                    cardNo = transactionInfo.cardNo,
+                    amount = transactionInfo.amount,
+                    status = TransactionStatusResponse.from(transactionInfo.status),
+                    reason = transactionInfo.reason,
+                )
+        }
+    }
+
+    data class TransactionResponse(
+        val transactionKey: String,
+        val status: TransactionStatusResponse,
+        val reason: String?,
+    ) {
+        companion object {
+            fun from(transactionInfo: TransactionInfo): TransactionResponse =
+                TransactionResponse(
+                    transactionKey = transactionInfo.transactionKey,
+                    status = TransactionStatusResponse.from(transactionInfo.status),
+                    reason = transactionInfo.reason,
+                )
+        }
+    }
+
+    data class OrderResponse(
+        val orderId: String,
+        val transactions: List<TransactionResponse>,
+    ) {
+        companion object {
+            fun from(orderInfo: OrderInfo): OrderResponse =
+                OrderResponse(
+                    orderId = orderInfo.orderId,
+                    transactions = orderInfo.transactions.map { TransactionResponse.from(it) },
+                )
+        }
+    }
+
+    enum class CardTypeDto {
+        SAMSUNG,
+        KB,
+        HYUNDAI,
+        ;
+
+        fun toCardType(): CardType = when (this) {
+            SAMSUNG -> CardType.SAMSUNG
+            KB -> CardType.KB
+            HYUNDAI -> CardType.HYUNDAI
+        }
+
+        companion object {
+            fun from(cardType: CardType) = when (cardType) {
+                CardType.SAMSUNG -> SAMSUNG
+                CardType.KB -> KB
+                CardType.HYUNDAI -> HYUNDAI
+            }
+        }
+    }
+
+    enum class TransactionStatusResponse {
+        PENDING,
+        SUCCESS,
+        FAILED,
+        ;
+
+        companion object {
+            fun from(transactionStatus: TransactionStatus) = when (transactionStatus) {
+                TransactionStatus.PENDING -> PENDING
+                TransactionStatus.SUCCESS -> SUCCESS
+                TransactionStatus.FAILED -> FAILED
+            }
+        }
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/event/payment/PaymentEventListener.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/event/payment/PaymentEventListener.kt
@@ -1,0 +1,28 @@
+package com.loopers.interfaces.event.payment
+
+import com.loopers.application.payment.PaymentApplicationService
+import com.loopers.domain.payment.PaymentEvent
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+@Component
+class PaymentEventListener(
+    private val paymentApplicationService: PaymentApplicationService,
+) {
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun handle(event: PaymentEvent.PaymentCreated) {
+        val thresholdMillis = (1000L..5000L).random()
+        Thread.sleep(thresholdMillis)
+
+        paymentApplicationService.handle(event.transactionKey)
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun handle(event: PaymentEvent.PaymentHandled) {
+        paymentApplicationService.notifyTransactionResult(transactionKey = event.transactionKey)
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/support/error/CoreException.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/support/error/CoreException.kt
@@ -1,0 +1,6 @@
+package com.loopers.support.error
+
+class CoreException(
+    val errorType: ErrorType,
+    val customMessage: String? = null,
+) : RuntimeException(customMessage ?: errorType.message)

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/support/error/ErrorType.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/support/error/ErrorType.kt
@@ -1,0 +1,11 @@
+package com.loopers.support.error
+
+import org.springframework.http.HttpStatus
+
+enum class ErrorType(val status: HttpStatus, val code: String, val message: String) {
+    /** 범용 에러 */
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, HttpStatus.INTERNAL_SERVER_ERROR.reasonPhrase, "일시적인 오류가 발생했습니다."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, HttpStatus.BAD_REQUEST.reasonPhrase, "잘못된 요청입니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, HttpStatus.NOT_FOUND.reasonPhrase, "존재하지 않는 요청입니다."),
+    CONFLICT(HttpStatus.CONFLICT, HttpStatus.CONFLICT.reasonPhrase, "이미 존재하는 리소스입니다."),
+}

--- a/apps/pg-simulator/src/main/resources/application.yml
+++ b/apps/pg-simulator/src/main/resources/application.yml
@@ -1,0 +1,77 @@
+server:
+  shutdown: graceful
+  tomcat:
+    threads:
+      max: 200 # 최대 워커 스레드 수 (default : 200)
+      min-spare: 10 # 최소 유지 스레드 수 (default : 10)
+    connection-timeout: 1m # 연결 타임아웃 (ms) (default : 60000ms = 1m)
+    max-connections: 8192 # 최대 동시 연결 수 (default : 8192)
+    accept-count: 100 # 대기 큐 크기 (default : 100)
+    keep-alive-timeout: 60s # 60s
+  max-http-request-header-size: 8KB
+
+spring:
+  main:
+    web-application-type: servlet
+  application:
+    name: commerce-api
+  profiles:
+    active: local
+  config:
+    import:
+      - jpa.yml
+      - redis.yml
+      - logging.yml
+      - monitoring.yml
+
+datasource:
+  mysql-jpa:
+    main:
+      jdbc-url: jdbc:mysql://localhost:3306/paymentgateway
+
+springdoc:
+  use-fqn: true
+  swagger-ui:
+    path: /swagger-ui.html
+
+---
+spring:
+  config:
+    activate:
+      on-profile: local, test
+
+server:
+  port: 8082
+
+management:
+  server:
+    port: 8083
+
+---
+spring:
+  config:
+    activate:
+      on-profile: dev
+
+server:
+  port: 8082
+
+management:
+  server:
+    port: 8083
+
+---
+spring:
+  config:
+    activate:
+      on-profile: qa
+
+---
+spring:
+  config:
+    activate:
+      on-profile: prd
+
+springdoc:
+  api-docs:
+    enabled: false

--- a/http/http-client.env.json
+++ b/http/http-client.env.json
@@ -1,5 +1,6 @@
 {
   "local": {
-    "commerce-api": "http://localhost:8080"
+    "commerce-api": "http://localhost:8080",
+    "pg-simulator": "http://localhost:8082"
   }
 }

--- a/http/pg-simulator/payments.http
+++ b/http/pg-simulator/payments.http
@@ -1,0 +1,20 @@
+### 결제 요청
+POST {{pg-simulator}}/api/v1/payments
+X-USER-ID: 135135
+Content-Type: application/json
+
+{
+  "orderId": "1351039135",
+  "cardType": "SAMSUNG",
+  "cardNo": "1234-5678-9814-1451",
+  "amount": "5000",
+  "callbackUrl": "http://localhost:8080/api/v1/examples/callback"
+}
+
+### 결제 정보 확인
+GET {{pg-simulator}}/api/v1/payments/20250816:TR:9577c5
+X-USER-ID: 135135
+
+### 주문에 엮인 결제 정보 조회
+GET {{pg-simulator}}/api/v1/payments?orderId=1351039135
+X-USER-ID: 135135

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,7 @@ rootProject.name = "e-commerce"
 
 include(
     ":apps:commerce-api",
+    ":apps:pg-simulator",
     ":modules:jpa",
     ":modules:redis",
     ":supports:jackson",


### PR DESCRIPTION
## 📌 Summary

* feat: pg 모듈 추가

* feat: 결제 도메인 추가

* feat: Feign 및 Resilience4j 설치와 세팅

* feat: 결제 도메인 분리 및 기능 구현

* feat: 스케줄러 적용

## 💬 Review Points

1.  트랜잭션 스코프가 분리되어야 할 때, 방법론.
비동기 혹은 API 호출로 인해 트랜잭션 스코프가 분리되어야 하면 그 이전 상태까지 완료되었다는 의미를 나타내는 PAY_WAITED 등의 점유/대기 이런 상태를  두고 커밋을 우선 한 뒤, 트랜잭션 스코프 바깥에서 분리해 처리할 작업을 수행 하고 나서야 PAY_WAITED -> PAY_COMPLETED 같이 이후 단계까지 완료 됐다는 의미를 나타내는 상태로 바꾸는...  이런식으로 작업을 처리해야 하나요? 
이런 상태를 매번 정의하고 관리 하에 두는 것도 번거로울 것 같은데 좋은 해결책이 있을까요?
2. 코드 구현 레벨 질문
2-1. 컨트롤러 혹은 어플리케이션 서비스 레이어에서 requestDTO에 다형성 쓰는 방식에 대해 어떻게 생각하시나요 (case 1 vs case 2)
```
# case 1
// controller or application service
abstract class PaymentRequest {
	PaymentMethod method;
}

class CardPaymentRequest extends PaymentRequest  {
	PaymentMethod method;
	CardInfo card;
}

class PointPaymentRequest extends PaymentRequest {
	PaymentMethod method;
	Point eventPoint;
}


# case 2
class PaymentRequest {
	PaymentMethod method;
	CardInfo card; // nullable
	Point eventPoint; // nullable
}

// case 2 쓰는 쪽:
if (paymentRequest.method == CARD) {
  // paymentRequest.method == CARD일 때 필요한 필드가 있다고 생각하며 dto 사용
}
```
2-2. 도메인 서비스에서 repository 이용하는 두 구현 방식 중  무엇이 좋을까요 + 그리고 A와 B 연계 작업을 돕는 도메인 서비스에서 A, B, C, D, E 여러 도메인의 레포지토리를 Dependency Injection 받아서 사용하는 것이 좋은 방향일까요 아니라면 생각하시는 대안은 무엇인가요?
```
// case 1.
// domain/payments
public class PointPaymentProcessor implements PaymentProcessor<PointPaymentRequest> {

    private final PointManager pointManager; // 타 도메인의 레포지토리 간접적으로 쓰려는 의도
    private final PaymentRepository paymentRepository; // payments 도메인에 직접적으로 속한 repository
    
}

// infra/members
public class MemberRepositoryImpl implements MemberRepository, PointManager {}

// case 2.
// domain/payments
public class PointPaymentProcessor implements PaymentProcessor<PointPaymentRequest> {

		// ...import from domain/members
    private final MemberRepository memberRepository; // 타 도메인의 레포지토리를 직접 가져와서 사용
    private final PaymentRepository paymentRepository; // payments 도메인에 직접적으로 속한 repository
    
}

// domain/members
public interface MemberRepository {}
// infra/members
public class MemberRepositoryImpl implements MemberRepository {}


```
2-3. repository 인터페이스에 비즈니스 로직에 대한 맥락을 담는 것에 대해 어떻게 생각하시나요 (case 1 vs 2)
```
// 목표: "생성된지 30분이 지났지만 여전히 PENDING 상태인" 만료된 결제 정보 조회 -> 취소 시켜라.

// case 1. 쓰는 쪽에서 비즈니스 로직에 맞게 인자 넣어서 기능 수행하기
interface AAArepository {
	// 쓰는 쪽이 최대한 커스텀해서 입맛대로 쓸 수 있게 제너럴/일반적인 네이밍으로 작명
	List<PaymentModel> findAllByStatusAndOlderThan(TransactionStatus status, LocalDateTime threshold);	
}

// 쓰는 쪽
findAllByStatusAndOlderThan(Status.PENDING, Date.now())


// case 2. 비즈니스 로직/정책을 담아서 쓰는 쪽에다가 제공하기
interface BBBrepository {
	List<PaymentModel> findAllExpiredPayment();	
}

class BBBrepositoryImpl implements BBBrepository {
	List<PaymentModel> findAllExpiredPayment() {
		쿼리 작성하는 내부에서 TransactionStatus status, LocalDateTime threshold 같은 정보를 사용
	}
}

```
2-4. API 호출과 DB 트랜잭션 스코프를 분리하기 위해 컨트롤러에서 어플리케이션 서비스의 호출 순서를 조립/결정하는 코드가 만들어졌습니다. 과연 괜찮은지, 그리고 어떻게 개선해야 했을까요 (특히 트랜잭션 내에서 수행하던 작업들 간의 스코프 분리가 필요해 질 경우, 내부 함수 호출로 코드 작성하면 프록시를 우회하기 때문에 트랜잭션이 적용되지 않는 현상이 발생할 수 있으므로 좀 각 작업을 어떤 식으로 분리할 지 고민이 되었습니다.)
```
@RequestMapping("/api/v1/orders")
public class OrderV1Controller implements OrderV1ApiSpec {

    @Override
    @PostMapping()
    public ApiResponse<OrderV1Dto.OrderResponse> order(
        @RequestHeader(value = "X-USER-ID", required = false) String userId,
        @RequestBody OrderV1Dto.OrderRequest dto
    ) {
         ...........       

        var result = commandOrderUseCase.execute( // 주문 생성
            new CommandOrderUseCase.Command(
                memberInfo,
                productIds,
                quantities,
                dto.couponId(),
                dto.card() != null ? dto.card().toInfo() : null
            )
        );

        var payment = paymentFacade.requestPayment( // 결제 생성
            new PaymentOrder(
                dto.card() != null ? PaymentOrder.PaymentMethod.CARD : PaymentOrder.PaymentMethod.POINTS,
                userId,
                result.orderInfo().id(),
                result.orderInfo().totalPrice(),
                dto.card() != null ? dto.card().cardType().toInfo() : null,
                dto.card() != null ? dto.card().cardNumber() : null
            )
        );
   }
}
```
3. 코드 구현 레벨에서 서킷 브레이커, PG 같은 외부 모듈 API 연계, FeignClient 에 대해 가지고 계신 멘토님만의 코드 구현 취향 및 팁이 있다면 궁금합니다.     

4. resilience4j 코어 모듈에는 서킷 브레이커 외에도 아래와 같은 것들이 있다고 나와 있는데, 각 기능에 대해 멘토님은 어떻게 용어 정의와 사용 용도를 규정하고 계신지 궁금합니다. 

4.1 [Bulkhead]

4.2 [RateLimiter]

4.3 [TimeLimiter]

4.4 [Cache]


## ✅ Checklist

### **⚡ PG 연동 대응**

- [x]  PG 연동 API는 RestTemplate 혹은 FeignClient 로 외부 시스템을 호출한다.
- [x]  응답 지연에 대해 타임아웃을 설정하고, 실패 시 적절한 예외 처리 로직을 구현한다.
- [x]  결제 요청에 대한 실패 응답에 대해 적절한 시스템 연동을 진행한다.
- [x]  콜백 방식 + **결제 상태 확인 API**를 활용해 적절하게 시스템과 결제정보를 연동한다.

### **🛡 Resilience 설계**

- [x]  서킷 브레이커 혹은 재시도 정책을 적용하여 장애 확산을 방지한다.
- [x]  외부 시스템 장애 시에도 내부 시스템은 **정상적으로 응답**하도록 보호한다.
- [x]  콜백이 오지 않더라도, 일정 주기 혹은 수동 API 호출로 상태를 복구할 수 있다.
- [x]  PG 에 대한 요청이 타임아웃에 의해 실패되더라도 해당 결제건에 대한 정보를 확인하여 정상적으로 시스템에 반영한다.